### PR TITLE
Adds the option to display the default image instead of the CORE name when the image is missing

### DIFF
--- a/arduino/tty2pico/.clang-format
+++ b/arduino/tty2pico/.clang-format
@@ -1,0 +1,6 @@
+Language: Cpp
+BasedOnStyle: Google
+
+UseTab: Always
+IndentWidth: 4
+TabWidth: 4

--- a/arduino/tty2pico/.clang-format
+++ b/arduino/tty2pico/.clang-format
@@ -4,3 +4,4 @@ BasedOnStyle: Google
 UseTab: Always
 IndentWidth: 4
 TabWidth: 4
+SortIncludes: false

--- a/arduino/tty2pico/include/commands.h
+++ b/arduino/tty2pico/include/commands.h
@@ -1,11 +1,12 @@
 #ifndef COMMANDS_H
 #define COMMANDS_H
 
-#include "config.h"
 #include <string>
+
+#include "config.h"
 #include "definitions.h"
-#include "platform.h"
 #include "display.h"
+#include "platform.h"
 #include "storage.h"
 #include "usbmsc.h"
 
@@ -13,240 +14,233 @@ using namespace std;
 
 static String coreName;
 
-static void cmdBye(void)
-{
-	showMister();
+static void cmdBye(void) { showMister(); }
+
+static void cmdCls(void) { clearDisplay(); }
+
+static void cmdDisplayOff(void) { digitalWrite(TFT_BL, LOW); }
+
+static void cmdDisplayOn(void) { digitalWrite(TFT_BL, HIGH); }
+
+static void cmdEnableOTA() {
+  Serial.println("Restarting in firmware update mode");
+  resetForUpdate();
 }
 
-static void cmdCls(void)
-{
-	clearDisplay();
+static void cmdGetTime(String command) {
+  int format = DTF_UNIX;
+  if (command.indexOf(',') > 0) {
+    String mode =
+        command.substring(command.indexOf(',') + 1, command.indexOf(',') + 2);
+    if (mode == "1") format = DTF_HUMAN;
+  }
+
+  const char *time = getTime(format);
+  Serial.println(time);
 }
 
-static void cmdDisplayOff(void)
-{
-	digitalWrite(TFT_BL, LOW);
+static void cmdGetSysInfo() {
+  string info = string("version:") + string(TTY2PICO_VERSION_STRING) +
+                string("|board:") + string(TTY2PICO_BOARD) +
+                string("|display:") + string(TTY2PICO_DISPLAY);
+
+  Serial.println(info.c_str());
 }
 
-static void cmdDisplayOn(void)
-{
-	digitalWrite(TFT_BL, HIGH);
-}
+static void cmdRotate(String command) {
+  if (command.indexOf(',') > -1) {
+    String mode =
+        command.substring(command.indexOf(',') + 1, command.indexOf(',') + 2);
+    int rotationMode = -1;
+    if (mode == "0")
+      rotationMode = 0;
+    else if (mode == "1")
+      rotationMode = 2;
+    else if (mode == "2")
+      rotationMode = 1;
+    else if (mode == "3")
+      rotationMode = 3;
 
-static void cmdEnableOTA()
-{
-	Serial.println("Restarting in firmware update mode");
-	resetForUpdate();
-}
-
-static void cmdGetTime(String command)
-{
-	int format = DTF_UNIX;
-	if (command.indexOf(',') > 0)
-	{
-		String mode = command.substring(command.indexOf(',') + 1, command.indexOf(',') + 2);
-		if (mode == "1")
-			format = DTF_HUMAN;
-	}
-
-	const char *time = getTime(format);
-	Serial.println(time);
-}
-
-static void cmdGetSysInfo()
-{
-	string info = string("version:")  + string(TTY2PICO_VERSION_STRING)
-	            + string("|board:")   + string(TTY2PICO_BOARD)
-	            + string("|display:") + string(TTY2PICO_DISPLAY);
-
-	Serial.println(info.c_str());
-}
-
-static void cmdRotate(String command)
-{
-	if (command.indexOf(',') > -1)
-	{
-		String mode = command.substring(command.indexOf(',') + 1, command.indexOf(',') + 2);
-		int rotationMode = -1;
-		if (mode == "0")
-			rotationMode = 0;
-		else if (mode == "1")
-			rotationMode = 2;
-		else if (mode == "2")
-			rotationMode = 1;
-		else if (mode == "3")
-			rotationMode = 3;
-
-		if (rotationMode < 0)
-		{
-			Serial.print("Invalid rotation mode: "); Serial.println(mode);
-			return;
-		}
+    if (rotationMode < 0) {
+      Serial.print("Invalid rotation mode: ");
+      Serial.println(mode);
+      return;
+    }
 
 #ifdef TFT_ROTATION
-		// Rotating needs to factor in the original rotation from TFT_ROTATION
-		rotationMode = (rotationMode + TFT_ROTATION) % 4;
+    // Rotating needs to factor in the original rotation from TFT_ROTATION
+    rotationMode = (rotationMode + TFT_ROTATION) % 4;
 #endif
-		tft.setRotation(rotationMode);
-		config.tftRotation = rotationMode;
-		saveConfig();
-		Serial.print("Rotation changed to "); Serial.println(mode);
-	}
-	else Serial.println("No rotation command found");
+    tft.setRotation(rotationMode);
+    config.tftRotation = rotationMode;
+    saveConfig();
+    Serial.print("Rotation changed to ");
+    Serial.println(mode);
+  } else
+    Serial.println("No rotation command found");
 }
 
-static void cmdSaver(String command)
-{
-	DisplayState lastDisplayState = getDisplayState();
-	if (command.indexOf(',') > -1 && command.length() > 9)
-	{
-		String mode = command.substring(command.indexOf(',') + 1, command.indexOf(',') + 2);
-		Serial.print("Screensaver mode changed to "); Serial.println(mode);
-		bool enabled = mode != "0";
-		if (enabled)
-			setDisplayState(DISPLAY_SLIDESHOW);
-		if (!enabled && lastDisplayState != DISPLAY_SLIDESHOW)
-			showStartup(); // Reset to startup image for now, might want to restore state later
-	}
-	else
-	{
-		setDisplayState(DISPLAY_SLIDESHOW);
-	}
+static void cmdSaver(String command) {
+  DisplayState lastDisplayState = getDisplayState();
+  if (command.indexOf(',') > -1 && command.length() > 9) {
+    String mode =
+        command.substring(command.indexOf(',') + 1, command.indexOf(',') + 2);
+    Serial.print("Screensaver mode changed to ");
+    Serial.println(mode);
+    bool enabled = mode != "0";
+    if (enabled) setDisplayState(DISPLAY_SLIDESHOW);
+    if (!enabled && lastDisplayState != DISPLAY_SLIDESHOW)
+      showStartup();  // Reset to startup image for now, might want to restore
+                      // state later
+  } else {
+    setDisplayState(DISPLAY_SLIDESHOW);
+  }
 }
 
-static void cmdSetCore(String command)
-{
-	if (command.startsWith(CMDCORE))
-		coreName = command.substring(command.indexOf(',') + 1, command.length());
-	else
-		coreName = command;
+static void cmdSetCore(String command) {
+  if (command.startsWith(CMDCORE))
+    coreName = command.substring(command.indexOf(',') + 1, command.length());
+  else
+    coreName = command;
 
-	String path;
-	bool found = false;
-	for (int i = 0; i < imageExtensionCount; i++)
-	{
-		// Check for animated file(s) first
-		path = config.imagePath + coreName + String(imageExtensions[i]);
+  String path;
+  bool found = false;
+  for (int i = 0; i < imageExtensionCount; i++) {
+    // Check for animated file(s) first
+    path = config.imagePath + coreName + String(imageExtensions[i]);
 #if VERBOSE_OUTPUT == 1
-	Serial.print("Checking for file "); Serial.println(path);
+    Serial.print("Checking for file ");
+    Serial.println(path);
 #endif
-		found = fileExists(path);
-		if (found)
-			break;
-	}
+    found = fileExists(path);
+    if (found) break;
+  }
 
-	if (found)
-	{
-		Serial.print("Loading "); Serial.println(path.c_str());
-		showImage(path);
-	}
-	else
-	{
-		Serial.print("Couldn't find core display file for "); Serial.println(coreName);
-		showText(coreName);
-	}
+  if (found) {
+    Serial.print("Loading ");
+    Serial.println(path.c_str());
+    showImage(path);
+  } else {
+    Serial.print("Couldn't find core display file for ");
+    Serial.println(coreName);
+    if (config.showDefaultForUnknown) {
+      showMister();
+    } else {
+      showText(coreName);
+    }
+  }
 }
 
-static void cmdSetTime(String command)
-{
-	if (command.indexOf(",") > 0)
-	{
-		String unixTimestamp = command.substring(command.indexOf(",") + 1);
-		uint32_t timestamp = unixTimestamp.toInt();
-		setTime(timestamp);
-	}
-	else Serial.println("Cannot set date and time, no data received");
+static void cmdSetTime(String command) {
+  if (command.indexOf(",") > 0) {
+    String unixTimestamp = command.substring(command.indexOf(",") + 1);
+    uint32_t timestamp = unixTimestamp.toInt();
+    setTime(timestamp);
+  } else
+    Serial.println("Cannot set date and time, no data received");
 }
 
-static void cmdShow(String command)
-{
-	String path = command.substring(command.indexOf(',') + 1);
-	showImage(path);
+static void cmdShow(String command) {
+  String path = command.substring(command.indexOf(',') + 1);
+  showImage(path);
 }
 
-static void cmdShowCoreName(void)
-{
-	showText(coreName);
+static void cmdShowCoreName(void) { showText(coreName); }
+
+static void cmdShowSystemInfo(void) { showSystemInfo(millis()); }
+
+static void cmdTest(void) {
+  showText("Starting test in...");
+  delay(2000);
+  showText("3");
+  delay(1000);
+  showText("2");
+  delay(1000);
+  showText("1");
+  delay(1000);
+  showSystemInfo(millis());
+  delay(3000);
+  for (int i = 0; i < 10; i++) showMister();
+  drawDemoShapes(5000);
+  if (fileExists(config.startupImage)) showImage(config.startupImage);
+  showText("Test complete!");
 }
 
-static void cmdShowSystemInfo(void)
-{
-	showSystemInfo(millis());
+static void cmdText(String command) {
+  String displayText;
+  if (command.startsWith(CMDTXT))
+    displayText = command.substring(command.indexOf(',') + 1, command.length());
+  else
+    displayText = command;
+
+  showText(displayText);
 }
 
-static void cmdTest(void)
-{
-	showText("Starting test in..."); delay(2000);
-	showText("3"); delay(1000);
-	showText("2"); delay(1000);
-	showText("1"); delay(1000);
-	showSystemInfo(millis());
-	delay(3000);
-	for (int i = 0; i < 10; i++) showMister();
-	drawDemoShapes(5000);
-	if (fileExists(config.startupImage)) showImage(config.startupImage);
-	showText("Test complete!");
-}
-
-static void cmdText(String command)
-{
-	String displayText;
-	if (command.startsWith(CMDTXT))
-		displayText = command.substring(command.indexOf(',') + 1, command.length());
-	else
-		displayText = command;
-
-	showText(displayText);
-}
-
-static void cmdUnknown(String command)
-{
+static void cmdUnknown(String command) {
 #if VERBOSE_OUTPUT == 1
-	Serial.print("Received unknown command: "); Serial.println(command);
+  Serial.print("Received unknown command: ");
+  Serial.println(command);
 #endif
-	showText(command);
+  showText(command);
 }
 
-void runCommand(CommandData data)
-{
-	switch (data.command)
-	{
-		case TTY2CMD_BYE:     return cmdBye();
-		case TTY2CMD_CLS:     return cmdCls();
-		case TTY2CMD_COR:     return cmdSetCore(data.commandText);
-		case TTY2CMD_DOFF:    return cmdDisplayOff();
-		case TTY2CMD_DON:     return cmdDisplayOn();
-		case TTY2CMD_ENOTA:   return cmdEnableOTA();
-		case TTY2CMD_GETSYS:  return cmdGetSysInfo();
-		case TTY2CMD_GETTIME: return cmdGetTime(data.commandText);
-		case TTY2CMD_ROT:     return cmdRotate(data.commandText);
-		case TTY2CMD_SAVER:   return cmdSaver(data.commandText);
-		case TTY2CMD_SETTIME: return cmdSetTime(data.commandText);
-		case TTY2CMD_SHSYSHW: return cmdShowSystemInfo();
-		case TTY2CMD_SWSAVER: return cmdSaver(data.commandText);
-		case TTY2CMD_SHOW:    return cmdShow(data.commandText);
-		case TTY2CMD_SHTEMP:  return cmdShowSystemInfo();
-		case TTY2CMD_SNAM:    return cmdShowCoreName();
-		case TTY2CMD_SORG:    return cmdShowSystemInfo();
-		case TTY2CMD_TEST:    return cmdTest();
-		case TTY2CMD_TXT:     return cmdText(data.commandText);
-		case TTY2CMD_UNKNOWN: return cmdUnknown(data.commandText);
-		case TTY2CMD_NONE:    return;
+void runCommand(CommandData data) {
+  switch (data.command) {
+    case TTY2CMD_BYE:
+      return cmdBye();
+    case TTY2CMD_CLS:
+      return cmdCls();
+    case TTY2CMD_COR:
+      return cmdSetCore(data.commandText);
+    case TTY2CMD_DOFF:
+      return cmdDisplayOff();
+    case TTY2CMD_DON:
+      return cmdDisplayOn();
+    case TTY2CMD_ENOTA:
+      return cmdEnableOTA();
+    case TTY2CMD_GETSYS:
+      return cmdGetSysInfo();
+    case TTY2CMD_GETTIME:
+      return cmdGetTime(data.commandText);
+    case TTY2CMD_ROT:
+      return cmdRotate(data.commandText);
+    case TTY2CMD_SAVER:
+      return cmdSaver(data.commandText);
+    case TTY2CMD_SETTIME:
+      return cmdSetTime(data.commandText);
+    case TTY2CMD_SHSYSHW:
+      return cmdShowSystemInfo();
+    case TTY2CMD_SWSAVER:
+      return cmdSaver(data.commandText);
+    case TTY2CMD_SHOW:
+      return cmdShow(data.commandText);
+    case TTY2CMD_SHTEMP:
+      return cmdShowSystemInfo();
+    case TTY2CMD_SNAM:
+      return cmdShowCoreName();
+    case TTY2CMD_SORG:
+      return cmdShowSystemInfo();
+    case TTY2CMD_TEST:
+      return cmdTest();
+    case TTY2CMD_TXT:
+      return cmdText(data.commandText);
+    case TTY2CMD_UNKNOWN:
+      return cmdUnknown(data.commandText);
+    case TTY2CMD_NONE:
+      return;
 
-		// If you get here you're missing an enum definition ^^^
-		default:
-			Serial.print("Unrecognized TTY2CMD command: ");
-			Serial.println(data.command);
-			return;
-	}
+    // If you get here you're missing an enum definition ^^^
+    default:
+      Serial.print("Unrecognized TTY2CMD command: ");
+      Serial.println(data.command);
+      return;
+  }
 }
 
-void loopQueue(void)
-{
-	static CommandData data;
+void loopQueue(void) {
+  static CommandData data;
 
-	while (removeFromQueue(data))
-		runCommand(data);
+  while (removeFromQueue(data)) runCommand(data);
 }
 
 #endif

--- a/arduino/tty2pico/include/commands.h
+++ b/arduino/tty2pico/include/commands.h
@@ -23,126 +23,132 @@ static void cmdDisplayOff(void) { digitalWrite(TFT_BL, LOW); }
 static void cmdDisplayOn(void) { digitalWrite(TFT_BL, HIGH); }
 
 static void cmdEnableOTA() {
-  Serial.println("Restarting in firmware update mode");
-  resetForUpdate();
+	Serial.println("Restarting in firmware update mode");
+	resetForUpdate();
 }
 
 static void cmdGetTime(String command) {
-  int format = DTF_UNIX;
-  if (command.indexOf(',') > 0) {
-    String mode =
-        command.substring(command.indexOf(',') + 1, command.indexOf(',') + 2);
-    if (mode == "1") format = DTF_HUMAN;
-  }
+	int format = DTF_UNIX;
+	if (command.indexOf(',') > 0) {
+		String mode = command.substring(command.indexOf(',') + 1,
+										command.indexOf(',') + 2);
+		if (mode == "1") format = DTF_HUMAN;
+	}
 
-  const char *time = getTime(format);
-  Serial.println(time);
+	const char *time = getTime(format);
+	Serial.println(time);
 }
 
 static void cmdGetSysInfo() {
-  string info = string("version:") + string(TTY2PICO_VERSION_STRING) +
-                string("|board:") + string(TTY2PICO_BOARD) +
-                string("|display:") + string(TTY2PICO_DISPLAY);
+	string info = string("version:") + string(TTY2PICO_VERSION_STRING) +
+				  string("|board:") + string(TTY2PICO_BOARD) +
+				  string("|display:") + string(TTY2PICO_DISPLAY);
 
-  Serial.println(info.c_str());
+	Serial.println(info.c_str());
 }
 
 static void cmdRotate(String command) {
-  if (command.indexOf(',') > -1) {
-    String mode =
-        command.substring(command.indexOf(',') + 1, command.indexOf(',') + 2);
-    int rotationMode = -1;
-    if (mode == "0")
-      rotationMode = 0;
-    else if (mode == "1")
-      rotationMode = 2;
-    else if (mode == "2")
-      rotationMode = 1;
-    else if (mode == "3")
-      rotationMode = 3;
+	if (command.indexOf(',') > -1) {
+		String mode = command.substring(command.indexOf(',') + 1,
+										command.indexOf(',') + 2);
+		int rotationMode = -1;
+		if (mode == "0")
+			rotationMode = 0;
+		else if (mode == "1")
+			rotationMode = 2;
+		else if (mode == "2")
+			rotationMode = 1;
+		else if (mode == "3")
+			rotationMode = 3;
 
-    if (rotationMode < 0) {
-      Serial.print("Invalid rotation mode: ");
-      Serial.println(mode);
-      return;
-    }
+		if (rotationMode < 0) {
+			Serial.print("Invalid rotation mode: ");
+			Serial.println(mode);
+			return;
+		}
 
 #ifdef TFT_ROTATION
-    // Rotating needs to factor in the original rotation from TFT_ROTATION
-    rotationMode = (rotationMode + TFT_ROTATION) % 4;
+		// Rotating needs to factor in the original rotation from TFT_ROTATION
+		rotationMode = (rotationMode + TFT_ROTATION) % 4;
 #endif
-    tft.setRotation(rotationMode);
-    config.tftRotation = rotationMode;
-    saveConfig();
-    Serial.print("Rotation changed to ");
-    Serial.println(mode);
-  } else
-    Serial.println("No rotation command found");
+		tft.setRotation(rotationMode);
+		config.tftRotation = rotationMode;
+		saveConfig();
+		Serial.print("Rotation changed to ");
+		Serial.println(mode);
+	} else
+		Serial.println("No rotation command found");
 }
 
 static void cmdSaver(String command) {
-  DisplayState lastDisplayState = getDisplayState();
-  if (command.indexOf(',') > -1 && command.length() > 9) {
-    String mode =
-        command.substring(command.indexOf(',') + 1, command.indexOf(',') + 2);
-    Serial.print("Screensaver mode changed to ");
-    Serial.println(mode);
-    bool enabled = mode != "0";
-    if (enabled) setDisplayState(DISPLAY_SLIDESHOW);
-    if (!enabled && lastDisplayState != DISPLAY_SLIDESHOW)
-      showStartup();  // Reset to startup image for now, might want to restore
-                      // state later
-  } else {
-    setDisplayState(DISPLAY_SLIDESHOW);
-  }
+	DisplayState lastDisplayState = getDisplayState();
+	if (command.indexOf(',') > -1 && command.length() > 9) {
+		String mode = command.substring(command.indexOf(',') + 1,
+										command.indexOf(',') + 2);
+		Serial.print("Screensaver mode changed to ");
+		Serial.println(mode);
+		bool enabled = mode != "0";
+		if (enabled) setDisplayState(DISPLAY_SLIDESHOW);
+		if (!enabled && lastDisplayState != DISPLAY_SLIDESHOW)
+			showStartup();	// Reset to startup image for now, might want to
+							// restore state later
+	} else {
+		setDisplayState(DISPLAY_SLIDESHOW);
+	}
 }
 
 static void cmdSetCore(String command) {
-  if (command.startsWith(CMDCORE))
-    coreName = command.substring(command.indexOf(',') + 1, command.length());
-  else
-    coreName = command;
+	if (command.startsWith(CMDCORE))
+		coreName =
+			command.substring(command.indexOf(',') + 1, command.length());
+	else
+		coreName = command;
 
-  String path;
-  bool found = false;
-  for (int i = 0; i < imageExtensionCount; i++) {
-    // Check for animated file(s) first
-    path = config.imagePath + coreName + String(imageExtensions[i]);
+	String path;
+	bool found = false;
+	for (int i = 0; i < imageExtensionCount; i++) {
+		// Check for animated file(s) first
+		path = config.imagePath + coreName + String(imageExtensions[i]);
 #if VERBOSE_OUTPUT == 1
-    Serial.print("Checking for file ");
-    Serial.println(path);
+		Serial.print("Checking for file ");
+		Serial.println(path);
 #endif
-    found = fileExists(path);
-    if (found) break;
-  }
+		found = fileExists(path);
+		if (found) break;
+	}
 
-  if (found) {
-    Serial.print("Loading ");
-    Serial.println(path.c_str());
-    showImage(path);
-  } else {
-    Serial.print("Couldn't find core display file for ");
-    Serial.println(coreName);
-    if (config.showDefaultForUnknown) {
-      showMister();
-    } else {
-      showText(coreName);
-    }
-  }
+	if (found) {
+		Serial.print("Loading ");
+		Serial.println(path.c_str());
+		showImage(path);
+	} else {
+		Serial.print("Couldn't find core display file for ");
+		Serial.println(coreName);
+		Serial.println(config.missingCoreImage);
+		if (config.missingCoreImage != "") {
+			if (config.missingCoreImage == "startup") {
+				showStartupImage();
+			} else {
+				showImage(config.missingCoreImage);
+			}
+		} else {
+			showText(coreName);
+		}
+	}
 }
 
 static void cmdSetTime(String command) {
-  if (command.indexOf(",") > 0) {
-    String unixTimestamp = command.substring(command.indexOf(",") + 1);
-    uint32_t timestamp = unixTimestamp.toInt();
-    setTime(timestamp);
-  } else
-    Serial.println("Cannot set date and time, no data received");
+	if (command.indexOf(",") > 0) {
+		String unixTimestamp = command.substring(command.indexOf(",") + 1);
+		uint32_t timestamp = unixTimestamp.toInt();
+		setTime(timestamp);
+	} else
+		Serial.println("Cannot set date and time, no data received");
 }
 
 static void cmdShow(String command) {
-  String path = command.substring(command.indexOf(',') + 1);
-  showImage(path);
+	String path = command.substring(command.indexOf(',') + 1);
+	showImage(path);
 }
 
 static void cmdShowCoreName(void) { showText(coreName); }
@@ -150,97 +156,102 @@ static void cmdShowCoreName(void) { showText(coreName); }
 static void cmdShowSystemInfo(void) { showSystemInfo(millis()); }
 
 static void cmdTest(void) {
-  showText("Starting test in...");
-  delay(2000);
-  showText("3");
-  delay(1000);
-  showText("2");
-  delay(1000);
-  showText("1");
-  delay(1000);
-  showSystemInfo(millis());
-  delay(3000);
-  for (int i = 0; i < 10; i++) showMister();
-  drawDemoShapes(5000);
-  if (fileExists(config.startupImage)) showImage(config.startupImage);
-  showText("Test complete!");
+	showText("Starting test in...");
+	delay(2000);
+	showText("3");
+	delay(1000);
+	showText("2");
+	delay(1000);
+	showText("1");
+	delay(1000);
+	showSystemInfo(millis());
+	delay(3000);
+	for (int i = 0; i < 10; i++) showMister();
+	drawDemoShapes(5000);
+	if (fileExists(config.startupImage)) showImage(config.startupImage);
+	showText("Test complete!");
 }
 
 static void cmdText(String command) {
-  String displayText;
-  if (command.startsWith(CMDTXT))
-    displayText = command.substring(command.indexOf(',') + 1, command.length());
-  else
-    displayText = command;
+	String displayText;
+	if (command.startsWith(CMDTXT))
+		displayText =
+			command.substring(command.indexOf(',') + 1, command.length());
+	else
+		displayText = command;
 
-  showText(displayText);
+	showText(displayText);
 }
+
+static void cmdReloadConfig() { loadConfig(); }
 
 static void cmdUnknown(String command) {
 #if VERBOSE_OUTPUT == 1
-  Serial.print("Received unknown command: ");
-  Serial.println(command);
+	Serial.print("Received unknown command: ");
+	Serial.println(command);
 #endif
-  showText(command);
+	showText(command);
 }
 
 void runCommand(CommandData data) {
-  switch (data.command) {
-    case TTY2CMD_BYE:
-      return cmdBye();
-    case TTY2CMD_CLS:
-      return cmdCls();
-    case TTY2CMD_COR:
-      return cmdSetCore(data.commandText);
-    case TTY2CMD_DOFF:
-      return cmdDisplayOff();
-    case TTY2CMD_DON:
-      return cmdDisplayOn();
-    case TTY2CMD_ENOTA:
-      return cmdEnableOTA();
-    case TTY2CMD_GETSYS:
-      return cmdGetSysInfo();
-    case TTY2CMD_GETTIME:
-      return cmdGetTime(data.commandText);
-    case TTY2CMD_ROT:
-      return cmdRotate(data.commandText);
-    case TTY2CMD_SAVER:
-      return cmdSaver(data.commandText);
-    case TTY2CMD_SETTIME:
-      return cmdSetTime(data.commandText);
-    case TTY2CMD_SHSYSHW:
-      return cmdShowSystemInfo();
-    case TTY2CMD_SWSAVER:
-      return cmdSaver(data.commandText);
-    case TTY2CMD_SHOW:
-      return cmdShow(data.commandText);
-    case TTY2CMD_SHTEMP:
-      return cmdShowSystemInfo();
-    case TTY2CMD_SNAM:
-      return cmdShowCoreName();
-    case TTY2CMD_SORG:
-      return cmdShowSystemInfo();
-    case TTY2CMD_TEST:
-      return cmdTest();
-    case TTY2CMD_TXT:
-      return cmdText(data.commandText);
-    case TTY2CMD_UNKNOWN:
-      return cmdUnknown(data.commandText);
-    case TTY2CMD_NONE:
-      return;
+	switch (data.command) {
+		case TTY2CMD_BYE:
+			return cmdBye();
+		case TTY2CMD_CLS:
+			return cmdCls();
+		case TTY2CMD_COR:
+			return cmdSetCore(data.commandText);
+		case TTY2CMD_DOFF:
+			return cmdDisplayOff();
+		case TTY2CMD_DON:
+			return cmdDisplayOn();
+		case TTY2CMD_ENOTA:
+			return cmdEnableOTA();
+		case TTY2CMD_GETSYS:
+			return cmdGetSysInfo();
+		case TTY2CMD_GETTIME:
+			return cmdGetTime(data.commandText);
+		case TTY2CMD_ROT:
+			return cmdRotate(data.commandText);
+		case TTY2CMD_SAVER:
+			return cmdSaver(data.commandText);
+		case TTY2CMD_SETTIME:
+			return cmdSetTime(data.commandText);
+		case TTY2CMD_SHSYSHW:
+			return cmdShowSystemInfo();
+		case TTY2CMD_SWSAVER:
+			return cmdSaver(data.commandText);
+		case TTY2CMD_SHOW:
+			return cmdShow(data.commandText);
+		case TTY2CMD_SHTEMP:
+			return cmdShowSystemInfo();
+		case TTY2CMD_SNAM:
+			return cmdShowCoreName();
+		case TTY2CMD_SORG:
+			return cmdShowSystemInfo();
+		case TTY2CMD_TEST:
+			return cmdTest();
+		case TTY2CMD_TXT:
+			return cmdText(data.commandText);
+		case TTY2CMD_RLCONF:
+			return cmdReloadConfig();
+		case TTY2CMD_UNKNOWN:
+			return cmdUnknown(data.commandText);
+		case TTY2CMD_NONE:
+			return;
 
-    // If you get here you're missing an enum definition ^^^
-    default:
-      Serial.print("Unrecognized TTY2CMD command: ");
-      Serial.println(data.command);
-      return;
-  }
+		// If you get here you're missing an enum definition ^^^
+		default:
+			Serial.print("Unrecognized TTY2CMD command: ");
+			Serial.println(data.command);
+			return;
+	}
 }
 
 void loopQueue(void) {
-  static CommandData data;
+	static CommandData data;
 
-  while (removeFromQueue(data)) runCommand(data);
+	while (removeFromQueue(data)) runCommand(data);
 }
 
 #endif

--- a/arduino/tty2pico/include/config.h
+++ b/arduino/tty2pico/include/config.h
@@ -3,27 +3,33 @@
 
 #include <Arduino.h>
 #include <stdint.h>
+
 #include "tomlcpp.hpp"
 #include "utils.h"
 
 #ifndef CONFIG_FILE_PATH
-#define CONFIG_FILE_PATH "/tty2pico.toml" // Path to tty2pico config file
+#define CONFIG_FILE_PATH "/tty2pico.toml"  // Path to tty2pico config file
 #endif
 
 #ifndef RESERVED_FLASH_KB
-#define RESERVED_FLASH_KB 512 // The amount of flash (in KB) reserved for program code
+#define RESERVED_FLASH_KB \
+	512	 // The amount of flash (in KB) reserved for program code
 #endif
 
 #ifndef DISK_LABEL
-#define DISK_LABEL "TTY2PICO" // Default label for newly formatted filesystem, limit of 11 characters
+#define DISK_LABEL \
+	"TTY2PICO"	// Default label for newly formatted filesystem, limit of 11
+				// characters
 #endif
 
 #ifndef VERBOSE_OUTPUT
-#define VERBOSE_OUTPUT 0 // Log a lot of stuff to the serial output, only useful for debugging
+#define VERBOSE_OUTPUT \
+	0  // Log a lot of stuff to the serial output, only useful for debugging
 #endif
 
 #ifndef WAIT_FOR_SERIAL
-#define WAIT_FOR_SERIAL 0 // Wait for serial connection before running program code
+#define WAIT_FOR_SERIAL \
+	0  // Wait for serial connection before running program code
 #endif
 
 /**************************
@@ -31,15 +37,16 @@
  **************************/
 
 #ifndef LOGO_PATH
-#define LOGO_PATH "/logos/" // Path to logo folder
+#define LOGO_PATH "/logos/"	 // Path to logo folder
 #endif
 
 #ifndef STARTUP_DELAY
-#define STARTUP_DELAY 5000 // The amount of time to display the startup screen
+#define STARTUP_DELAY 5000	// The amount of time to display the startup screen
 #endif
 
 #ifndef STARTUP_LOGO
-#define STARTUP_LOGO "" // The logo to show on startup (when not in slideshow mode)
+#define STARTUP_LOGO \
+	""	// The logo to show on startup (when not in slideshow mode)
 #endif
 
 #ifndef BACKGROUND_COLOR
@@ -68,15 +75,15 @@
 // SILVER      0xC618      /* 192, 192, 192 */
 // SKYBLUE     0x867D      /* 135, 206, 235 */
 // VIOLET      0x915C      /* 180,  46, 226 */
-#define BACKGROUND_COLOR 0x0000 // The default background color
+#define BACKGROUND_COLOR 0x0000	 // The default background color
 #endif
 
 #ifndef SLIDESHOW_DELAY
-#define SLIDESHOW_DELAY 2000 // The time between slideshow changes
+#define SLIDESHOW_DELAY 2000  // The time between slideshow changes
 #endif
 
 #ifndef TFT_ROTATION
-#define TFT_ROTATION 0 // Set the rotation position, values are from 0-3
+#define TFT_ROTATION 0	// Set the rotation position, values are from 0-3
 #endif
 
 #ifndef SHOW_FPS
@@ -84,19 +91,25 @@
 #endif
 
 #ifndef USE_DMA
-#define USE_DMA 0 // If defined will use the DMA mode with TFT_eSPI library for better performance on supported hardware
+#define USE_DMA \
+	0  // If defined will use the DMA mode with TFT_eSPI library for better
+	   // performance on supported hardware
 #endif
 
 #ifndef USE_DMA_SD
-#define USE_DMA_SD 0 // If defined will use the DMA mode with SD card for better performance on supported hardware
+#define USE_DMA_SD \
+	0  // If defined will use the DMA mode with SD card for better
+	   // performance on supported hardware
 #endif
 
 #ifndef CPU_BOOST
-#define CPU_BOOST 1 // Enable a slight boost over the standard overclock (if available for platform), will have slight effect SD SPI rate
+#define CPU_BOOST \
+	1  // Enable a slight boost over the standard overclock (if available
+	   // for platform), will have slight effect SD SPI rate
 #endif
 
 #ifndef SD_MODE
-#define SD_MODE 0 // See TTY2PICO_SdModes for details
+#define SD_MODE 0  // See TTY2PICO_SdModes for details
 #endif
 
 /**************************
@@ -136,31 +149,44 @@
  **************************/
 
 typedef enum TTY2PICO_Font {
-	// GFXFF =  FreeFonts. Include access to the 48 Adafruit_GFX free fonts FF1 to FF48 and custom fonts
-	GLCD = 1, // Font 1. Original Adafruit 8 pixel font needs ~1820 bytes in FLASH
-	FONT2 = 2, // Font 2. Small 16 pixel high font, needs ~3534 bytes in FLASH, 96 characters
-	FONT4 = 4, // Font 4. Medium 26 pixel high font, needs ~5848 bytes in FLASH, 96 characters
-	FONT6 = 6, // Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH, only characters 1234567890:-.apm
-	FONT7 = 7, // Font 7. 7 segment 48 pixel font, needs ~2438 bytes in FLASH, only characters 1234567890:.
-	FONT8 = 8, // Font 8. Large 75 pixel font needs ~3256 bytes in FLASH, only characters 1234567890:-.
+	// GFXFF =  FreeFonts. Include access to the 48 Adafruit_GFX free fonts
+	// FF1
+	// to
+	// FF48 and custom fonts
+	GLCD = 1,	// Font 1. Original Adafruit 8 pixel font needs ~1820 bytes
+				// in FLASH
+	FONT2 = 2,	// Font 2. Small 16 pixel high font, needs ~3534 bytes in
+				// FLASH, 96 characters
+	FONT4 = 4,	// Font 4. Medium 26 pixel high font, needs ~5848 bytes in
+				// FLASH,
+				// 96 characters
+	FONT6 = 6,	// Font 6. Large 48 pixel font, needs ~2666 bytes in FLASH,
+				// only characters 1234567890:-.apm
+	FONT7 = 7,	// Font 7. 7 segment 48 pixel font, needs ~2438 bytes in
+				// FLASH, only characters 1234567890:.
+	FONT8 = 8,	// Font 8. Large 75 pixel font needs ~3256 bytes in FLASH,
+				// only characters 1234567890:-.
 } TTY2PICO_Font;
 
-typedef enum TTY2PICO_SdModes
-{
-	SD_MODE_DEFAULT = 0, // 25.0MHz CPU@250MHz | 26.7MHz CPU@266MHz (1:1 peripheral clock)
-	SD_MODE_HIGH,        // 32.2MHz CPU@250MHz | 33.3MHz CPU@266MHz (1:1 peripheral clock)
-	SD_MODE_MAX,         // 41.3MHz CPU@250MHz | 44.3MHz CPU@266MHz (1:1 peripheral clock)
+typedef enum TTY2PICO_SdModes {
+	SD_MODE_DEFAULT = 0,  // 25.0MHz CPU@250MHz | 26.7MHz CPU@266MHz (1:1
+						  // peripheral clock)
+	SD_MODE_HIGH,		  // 32.2MHz CPU@250MHz | 33.3MHz CPU@266MHz (1:1
+						  // peripheral clock)
+	SD_MODE_MAX,  // 41.3MHz CPU@250MHz | 44.3MHz CPU@266MHz (1:1 peripheral
+				  // clock)
 } TTY2PICO_SdModes;
 
-const int SD_MODE_SPEEDS[] =
-{
-	27, // SD_SPEED_DEFAULT - 25.0MHz CPU@250MHz | 26.7MHz CPU@266MHz (1:1 peripheral clock)
-	34, // SD_SPEED_HIGH    - 32.2MHz CPU@250MHz | 33.3MHz CPU@266MHz (1:1 peripheral clock)
-	45, // SD_SPEED_MAX     - 41.3MHz CPU@250MHz | 44.3MHz CPU@266MHz (1:1 peripheral clock)
+const int SD_MODE_SPEEDS[] = {
+	27,	 // SD_SPEED_DEFAULT - 25.0MHz CPU@250MHz | 26.7MHz CPU@266MHz (1:1
+		 // peripheral clock)
+	34,	 // SD_SPEED_HIGH    - 32.2MHz CPU@250MHz | 33.3MHz CPU@266MHz (1:1
+		 // peripheral clock)
+	45,	 // SD_SPEED_MAX     - 41.3MHz CPU@250MHz | 44.3MHz CPU@266MHz (1:1
+		 // peripheral clock)
 };
 
-struct TTY2PICO_Config
-{
+struct TTY2PICO_Config {
 	uint16_t backgroundColor = BACKGROUND_COLOR;
 	String imagePath = LOGO_PATH;
 	bool cpuBoost = CPU_BOOST;
@@ -174,14 +200,21 @@ struct TTY2PICO_Config
 	int tftWidth = TFT_WIDTH;
 	int tftHeight = TFT_HEIGHT;
 	bool uncapFramerate = false;
+	bool showDefaultForUnknown = false;
 
-	int getDisplayHeight() const { return tftHeight < tftWidth ? tftHeight : tftWidth; }
-	int getDisplayWidth() const { return tftWidth > tftHeight ? tftWidth : tftHeight; }
+	int getDisplayHeight() const {
+		return tftHeight < tftWidth ? tftHeight : tftWidth;
+	}
+	int getDisplayWidth() const {
+		return tftWidth > tftHeight ? tftWidth : tftHeight;
+	}
 	int getMidpointX() const { return getDisplayWidth() / 2; }
 	int getMidpointY() const { return getDisplayHeight() / 2; }
 	int getLineBufferSize() const { return getDisplayWidth(); }
 	int getFontSmall() const { return getDisplayHeight() < 160 ? GLCD : FONT2; }
-	int getFontLarge() const { return getDisplayHeight() < 160 ? FONT2 : FONT4; }
+	int getFontLarge() const {
+		return getDisplayHeight() < 160 ? FONT2 : FONT4;
+	}
 	int getFontSmallSize() const { return getDisplayHeight() < 160 ? 8 : 16; }
 	int getFontLargeSize() const { return getDisplayHeight() < 160 ? 16 : 26; }
 };
@@ -189,8 +222,7 @@ struct TTY2PICO_Config
 TTY2PICO_Config config;
 
 // Parses a tty2pico config from memory. Will return an error message if failed.
-const char *parseConfig(char *buffer)
-{
+const char *parseConfig(char *buffer) {
 	// Do we have a config to parse?
 	if (buffer == nullptr || sizeof(buffer) == 0)
 		return "No config data present";
@@ -199,14 +231,15 @@ const char *parseConfig(char *buffer)
 	trimTrailing(buffer);
 
 	auto res = toml::parse(buffer);
-	if (!res.table)
-		return res.errmsg.c_str();
+	if (!res.table) return res.errmsg.c_str();
 
 	auto tty2pico = res.table->getTable("tty2pico");
 	if (!tty2pico)
-		return "Invalid configuration file, missing [tty2pico] config section";
+		return "Invalid configuration file, missing [tty2pico] config "
+			   "section";
 
-	auto [backgroundColorOK, backgroundColor] = tty2pico->getInt("backgroundColor");
+	auto [backgroundColorOK, backgroundColor] =
+		tty2pico->getInt("backgroundColor");
 	if (backgroundColorOK) config.backgroundColor = (uint16_t)backgroundColor;
 
 	auto [cpuBoostOK, cpuBoost] = tty2pico->getBool("cpuBoost");
@@ -216,16 +249,23 @@ const char *parseConfig(char *buffer)
 	if (imagePathOK) config.imagePath = imagePath.c_str();
 
 	auto [sdModeOK, sdMode] = tty2pico->getInt("sdMode");
-	if (sdModeOK) config.sdMode = (sdMode >= SD_MODE_DEFAULT && sdMode <= SD_MODE_MAX) ? (TTY2PICO_SdModes)sdMode : SD_MODE_DEFAULT;
+	if (sdModeOK)
+		config.sdMode = (sdMode >= SD_MODE_DEFAULT && sdMode <= SD_MODE_MAX)
+							? (TTY2PICO_SdModes)sdMode
+							: SD_MODE_DEFAULT;
 
-	auto [slideshowDelayOK, slideshowDelay] = tty2pico->getInt("slideshowDelay");
+	auto [slideshowDelayOK, slideshowDelay] =
+		tty2pico->getInt("slideshowDelay");
 	if (slideshowDelayOK) config.slideshowDelay = (uint32_t)slideshowDelay;
 
-	auto [slideshowFolderOK, slideshowFolder] = tty2pico->getString("slideshowFolder");
+	auto [slideshowFolderOK, slideshowFolder] =
+		tty2pico->getString("slideshowFolder");
 	if (slideshowFolderOK) config.slideshowFolder = slideshowFolder.c_str();
 
-	auto [startupCommandOK, startupCommand] = tty2pico->getString("startupCommand");
-	if (startupCommandOK && startupCommand.length() > 0) config.startupCommand = startupCommand.c_str();
+	auto [startupCommandOK, startupCommand] =
+		tty2pico->getString("startupCommand");
+	if (startupCommandOK && startupCommand.length() > 0)
+		config.startupCommand = startupCommand.c_str();
 
 	auto [startupDelayOK, startupDelay] = tty2pico->getInt("startupDelay");
 	if (startupDelayOK) config.startupDelay = (unsigned long)startupDelay;
@@ -242,30 +282,43 @@ const char *parseConfig(char *buffer)
 	auto [tftRotationOK, tftRotation] = tty2pico->getInt("tftRotation");
 	if (tftRotationOK) config.tftRotation = (uint8_t)tftRotation;
 
-	auto [uncapFramerateOK, uncapFramerate] = tty2pico->getBool("uncapFramerate");
+	auto [uncapFramerateOK, uncapFramerate] =
+		tty2pico->getBool("uncapFramerate");
 	if (uncapFramerateOK) config.uncapFramerate = uncapFramerate;
+
+	auto [showDefaultForUnknownOK, showDefaultForUnknown] =
+		tty2pico->getBool("showDefaultForUnknown");
+	if (showDefaultForUnknownOK)
+		config.showDefaultForUnknown = showDefaultForUnknown;
 
 	return nullptr;
 }
 
-int exportConfig(char *buffer, int bufferSize)
-{
+int exportConfig(char *buffer, int bufferSize) {
 	String commandText =
-		String("title = \"tty2pico Configuration\"\n") +
-		"\n[tty2pico]" +
+		String("title = \"tty2pico Configuration\"\n") + "\n[tty2pico]" +
 		"\nbackgroundColor = " + String(config.backgroundColor) +
 		"\ncpuBoost = " + String(config.cpuBoost ? "true" : "false") +
 		"\nimagePath = \"" + config.imagePath + "\"" +
-		"\nsdMode = " + String(config.sdMode) +
-		"\nstartupCommand = \"" + config.startupCommand + "\"" +
+		"\nsdMode = " + String(config.sdMode) + "\nstartupCommand = \"" +
+		config.startupCommand + "\"" +
 		"\nstartupDelay = " + String(config.startupDelay) +
 		"\nstartupImage = \"" + config.startupImage + "\"" +
 		"\nslideshowDelay = " + String(config.slideshowDelay) +
 		"\nslideshowFolder = \"" + config.slideshowFolder + "\"" +
-		(TFT_WIDTH != config.tftWidth ? "\ntftWidth = " + String(config.tftWidth) : "") +
-		(TFT_HEIGHT != config.tftHeight ? "\ntftHeight = " + String(config.tftHeight) : "") +
-		(TFT_ROTATION != config.tftRotation ? "\ntftRotation = " + String(config.tftRotation) : "") +
-		"\nuncapFramerate = " + String(config.uncapFramerate ? "true" : "false");
+		(TFT_WIDTH != config.tftWidth
+			 ? "\ntftWidth = " + String(config.tftWidth)
+			 : "") +
+		(TFT_HEIGHT != config.tftHeight
+			 ? "\ntftHeight = " + String(config.tftHeight)
+			 : "") +
+		(TFT_ROTATION != config.tftRotation
+			 ? "\ntftRotation = " + String(config.tftRotation)
+			 : "") +
+		"\nuncapFramerate = " +
+		String(config.uncapFramerate ? "true" : "false") +
+		"\nshowDefaultForUnknown = " +
+		String(config.showDefaultForUnknown ? "true" : "false");
 
 	memcpy(buffer, commandText.c_str(), commandText.length());
 	return commandText.length();

--- a/arduino/tty2pico/include/config.h
+++ b/arduino/tty2pico/include/config.h
@@ -165,7 +165,7 @@ typedef enum TTY2PICO_Font {
 	FONT7 = 7,	// Font 7. 7 segment 48 pixel font, needs ~2438 bytes in
 				// FLASH, only characters 1234567890:.
 	FONT8 = 8,	// Font 8. Large 75 pixel font needs ~3256 bytes in FLASH,
-				// only characters 1234567890:-.
+	// only characters 1234567890:-.
 } TTY2PICO_Font;
 
 typedef enum TTY2PICO_SdModes {
@@ -200,7 +200,7 @@ struct TTY2PICO_Config {
 	int tftWidth = TFT_WIDTH;
 	int tftHeight = TFT_HEIGHT;
 	bool uncapFramerate = false;
-	bool showDefaultForUnknown = false;
+	String missingCoreImage = "";
 
 	int getDisplayHeight() const {
 		return tftHeight < tftWidth ? tftHeight : tftWidth;
@@ -286,10 +286,9 @@ const char *parseConfig(char *buffer) {
 		tty2pico->getBool("uncapFramerate");
 	if (uncapFramerateOK) config.uncapFramerate = uncapFramerate;
 
-	auto [showDefaultForUnknownOK, showDefaultForUnknown] =
-		tty2pico->getBool("showDefaultForUnknown");
-	if (showDefaultForUnknownOK)
-		config.showDefaultForUnknown = showDefaultForUnknown;
+	auto [missingCoreImageOK, missingCoreImage] =
+		tty2pico->getString("missingCoreImage");
+	if (missingCoreImageOK) config.missingCoreImage = missingCoreImage.c_str();
 
 	return nullptr;
 }
@@ -317,8 +316,7 @@ int exportConfig(char *buffer, int bufferSize) {
 			 : "") +
 		"\nuncapFramerate = " +
 		String(config.uncapFramerate ? "true" : "false") +
-		"\nshowDefaultForUnknown = " +
-		String(config.showDefaultForUnknown ? "true" : "false");
+		"\nmissingCoreImage = \"" + config.missingCoreImage + "\"";
 
 	memcpy(buffer, commandText.c_str(), commandText.length());
 	return commandText.length();

--- a/arduino/tty2pico/include/definitions.h
+++ b/arduino/tty2pico/include/definitions.h
@@ -10,32 +10,34 @@
 // When adding a new command do the following:
 // * Add a `const String [CMDNAME]` variable to commands.h
 // * Add to TTY2CMD enum to commands.h
-// * Add or use existing function for handling command, prefix function name with `cmd`
+// * Add or use existing function for handling command, prefix function name
+// with `cmd`
 // * Add handling to `parseCommand()` and `runCommand()`
 // * Document where appropriate
 
 // tty2oled commands
-const String CMDBYE     = "CMDBYE";
-const String CMDCLS     = "CMDCLS";
-const String CMDCORE    = "CMDCOR";
-const String CMDDOFF    = "CMDDOFF";
-const String CMDDON     = "CMDDON";
-const String CMDENOTA   = "CMDENOTA";
-const String CMDROT     = "CMDROT";
-const String CMDSAVER   = "CMDSAVER";
+const String CMDBYE = "CMDBYE";
+const String CMDCLS = "CMDCLS";
+const String CMDCORE = "CMDCOR";
+const String CMDDOFF = "CMDDOFF";
+const String CMDDON = "CMDDON";
+const String CMDENOTA = "CMDENOTA";
+const String CMDROT = "CMDROT";
+const String CMDSAVER = "CMDSAVER";
 const String CMDSETTIME = "CMDSETTIME";
 const String CMDSHSYSHW = "CMDSHSYSHW";
-const String CMDSHTEMP  = "CMDSHTEMP";
-const String CMDSNAM    = "CMDSNAM";
-const String CMDSORG    = "CMDSORG";
+const String CMDSHTEMP = "CMDSHTEMP";
+const String CMDSNAM = "CMDSNAM";
+const String CMDSORG = "CMDSORG";
 const String CMDSWSAVER = "CMDSWSAVER";
-const String CMDTEST    = "CMDTEST";
-const String CMDTXT     = "CMDTXT";
+const String CMDTEST = "CMDTEST";
+const String CMDTXT = "CMDTXT";
 
 // tty2pico commands
-const String CMDGETSYS  = "CMDGETSYS";
+const String CMDGETSYS = "CMDGETSYS";
 const String CMDGETTIME = "CMDGETTIME";
-const String CMDSHOW    = "CMDSHOW";
+const String CMDSHOW = "CMDSHOW";
+const String CMDRLCONF = "CMDRLCONF";
 
 typedef enum TTY2CMD {
 	TTY2CMD_NONE = 0,
@@ -60,41 +62,62 @@ typedef enum TTY2CMD {
 	TTY2CMD_TXT,
 	TTY2CMD_UNKNOWN,
 	TTY2CMD_USBMSC,
+	TTY2CMD_RLCONF
 } TTY2CMD;
 
-struct CommandData
-{
-	CommandData() { }
-	CommandData(TTY2CMD command) : command(command) { }
-	CommandData(TTY2CMD command, String commandText) : command(command), commandText(commandText) { }
+struct CommandData {
+	CommandData() {}
+	CommandData(TTY2CMD command) : command(command) {}
+	CommandData(TTY2CMD command, String commandText)
+		: command(command), commandText(commandText) {}
 
-	static CommandData parseCommand(String command)
-	{
+	static CommandData parseCommand(String command) {
 		String bigcmd = command;
 		bigcmd.toUpperCase();
 
-		if (bigcmd != "")
-		{
-			if      (bigcmd.startsWith(CMDBYE))                                  return CommandData(TTY2CMD_BYE, command);
-			else if (bigcmd.startsWith(CMDCLS))                                  return CommandData(TTY2CMD_CLS, command);
-			else if (bigcmd.startsWith(CMDDOFF))                                 return CommandData(TTY2CMD_DOFF, command);
-			else if (bigcmd.startsWith(CMDDON))                                  return CommandData(TTY2CMD_DON, command);
-			else if (bigcmd.startsWith(CMDENOTA))                                return CommandData(TTY2CMD_ENOTA, command);
-			else if (bigcmd.startsWith(CMDGETSYS))                               return CommandData(TTY2CMD_GETSYS, command);
-			else if (bigcmd.startsWith(CMDGETTIME))                              return CommandData(TTY2CMD_GETTIME, command);
-			else if (bigcmd.startsWith(CMDROT))                                  return CommandData(TTY2CMD_ROT, command);
-			else if (bigcmd.startsWith(CMDSAVER))                                return CommandData(TTY2CMD_SAVER, command);
-			else if (bigcmd.startsWith(CMDSETTIME))                              return CommandData(TTY2CMD_SETTIME, command);
-			else if (bigcmd.startsWith(CMDSHOW))                                 return CommandData(TTY2CMD_SHOW, command);
-			else if (bigcmd.startsWith(CMDSHSYSHW))                              return CommandData(TTY2CMD_SHSYSHW, command);
-			else if (bigcmd.startsWith(CMDSHTEMP))                               return CommandData(TTY2CMD_SHTEMP, command);
-			else if (bigcmd.startsWith(CMDSNAM))                                 return CommandData(TTY2CMD_SNAM, command);
-			else if (bigcmd.startsWith(CMDSORG))                                 return CommandData(TTY2CMD_SORG, command);
-			else if (bigcmd.startsWith(CMDSWSAVER))                              return CommandData(TTY2CMD_SWSAVER, command);
-			else if (bigcmd.startsWith(CMDTEST))                                 return CommandData(TTY2CMD_TEST, command);
-			else if (bigcmd.startsWith(CMDTXT))                                  return CommandData(TTY2CMD_TXT, command);
-			else if (bigcmd.startsWith("CMD") && !bigcmd.startsWith(CMDCORE))    return CommandData(TTY2CMD_UNKNOWN, command);
-			else    /* Assume core name if no command was matched */             return CommandData(TTY2CMD_COR, command);
+		if (bigcmd != "") {
+			if (bigcmd.startsWith(CMDBYE))
+				return CommandData(TTY2CMD_BYE, command);
+			else if (bigcmd.startsWith(CMDCLS))
+				return CommandData(TTY2CMD_CLS, command);
+			else if (bigcmd.startsWith(CMDDOFF))
+				return CommandData(TTY2CMD_DOFF, command);
+			else if (bigcmd.startsWith(CMDDON))
+				return CommandData(TTY2CMD_DON, command);
+			else if (bigcmd.startsWith(CMDENOTA))
+				return CommandData(TTY2CMD_ENOTA, command);
+			else if (bigcmd.startsWith(CMDGETSYS))
+				return CommandData(TTY2CMD_GETSYS, command);
+			else if (bigcmd.startsWith(CMDGETTIME))
+				return CommandData(TTY2CMD_GETTIME, command);
+			else if (bigcmd.startsWith(CMDROT))
+				return CommandData(TTY2CMD_ROT, command);
+			else if (bigcmd.startsWith(CMDSAVER))
+				return CommandData(TTY2CMD_SAVER, command);
+			else if (bigcmd.startsWith(CMDSETTIME))
+				return CommandData(TTY2CMD_SETTIME, command);
+			else if (bigcmd.startsWith(CMDSHOW))
+				return CommandData(TTY2CMD_SHOW, command);
+			else if (bigcmd.startsWith(CMDSHSYSHW))
+				return CommandData(TTY2CMD_SHSYSHW, command);
+			else if (bigcmd.startsWith(CMDSHTEMP))
+				return CommandData(TTY2CMD_SHTEMP, command);
+			else if (bigcmd.startsWith(CMDSNAM))
+				return CommandData(TTY2CMD_SNAM, command);
+			else if (bigcmd.startsWith(CMDSORG))
+				return CommandData(TTY2CMD_SORG, command);
+			else if (bigcmd.startsWith(CMDSWSAVER))
+				return CommandData(TTY2CMD_SWSAVER, command);
+			else if (bigcmd.startsWith(CMDTEST))
+				return CommandData(TTY2CMD_TEST, command);
+			else if (bigcmd.startsWith(CMDTXT))
+				return CommandData(TTY2CMD_TXT, command);
+			else if (bigcmd.startsWith(CMDRLCONF))
+				return CommandData(TTY2CMD_RLCONF, command);
+			else if (bigcmd.startsWith("CMD") && !bigcmd.startsWith(CMDCORE))
+				return CommandData(TTY2CMD_UNKNOWN, command);
+			else /* Assume core name if no command was matched */
+				return CommandData(TTY2CMD_COR, command);
 		}
 
 		return CommandData(TTY2CMD_NONE, command);
@@ -120,9 +143,8 @@ typedef enum DisplayState {
 	DISPLAY_SYSTEM_INFORMATION,
 } DisplayState;
 
-class SdSpiDriverT2P : public SdSpiBaseClass
-{
-public:
+class SdSpiDriverT2P : public SdSpiBaseClass {
+   public:
 	SdSpiDriverT2P();
 
 	// Activate SPI hardware with correct speed and mode.
@@ -143,20 +165,18 @@ public:
 	// Save SPISettings for new max SCK frequency
 	void setSckSpeed(uint32_t maxSck);
 
-private:
+   private:
 	SPISettings spiSettings;
 };
 
 class FsVolumeTS;
 
-class FsFileTS
-{
-public:
-	FsFileTS() { }
-	FsFileTS(File32 file) : file32(file) { }
-	FsFileTS(FsFile file) : fsFile(file) { }
-	~FsFileTS()
-	{
+class FsFileTS {
+   public:
+	FsFileTS() {}
+	FsFileTS(File32 file) : file32(file) {}
+	FsFileTS(FsFile file) : fsFile(file) {}
+	~FsFileTS() {
 		if (fsFile) fsFile.close();
 		if (file32) file32.close();
 	}
@@ -168,32 +188,30 @@ public:
 	bool available(void);
 	bool close(bool sync = false);
 	uint8_t getError() const;
-	size_t getName(char* name, size_t len);
+	size_t getName(char *name, size_t len);
 	bool isDir(void);
 	FsFileTS openNextFile(void);
-	bool openNext(FsBaseFile* dir, oflag_t oflag);
+	bool openNext(FsBaseFile *dir, oflag_t oflag);
 	uint64_t position(void);
 	size_t print(const char *str);
-	int read(void* buf, size_t count);
+	int read(void *buf, size_t count);
 	void rewindDirectory(void);
 	bool seek(uint64_t position);
 	uint64_t size(void);
-	size_t write(const void* buf, size_t count);
+	size_t write(const void *buf, size_t count);
 
-private:
+   private:
 	static FsVolumeTS *activeVolume;
 	File32 file32;
 	FsFile fsFile;
 };
 
-class FsVolumeTS
-{
-public:
-	FsVolumeTS() { }
-	FsVolumeTS(FatVolume *vol) : flashVol(vol) { }
-	FsVolumeTS(FsVolume *vol) : sdVol(vol) { }
-	~FsVolumeTS()
-	{
+class FsVolumeTS {
+   public:
+	FsVolumeTS() {}
+	FsVolumeTS(FatVolume *vol) : flashVol(vol) {}
+	FsVolumeTS(FsVolume *vol) : sdVol(vol) {}
+	~FsVolumeTS() {
 		flashVol = nullptr;
 		sdVol = nullptr;
 	}
@@ -206,7 +224,7 @@ public:
 	FatVolume *getFlashVol(void) { return flashVol; }
 	FsVolume *getSdVol(void) { return sdVol; }
 
-private:
+   private:
 	FatVolume *flashVol;
 	FsVolume *sdVol;
 };

--- a/arduino/tty2pico/include/display.h
+++ b/arduino/tty2pico/include/display.h
@@ -19,13 +19,10 @@ using namespace std;
 #define DISPLAY_TEXT_MARGIN 4
 
 const char *imageExtensions[] = {
-	".loop.fast.gif",
-	".loop.gif",
-	".fast.gif",
-	".gif",
-	".png",
+	".loop.fast.gif", ".loop.gif", ".fast.gif", ".gif", ".png",
 };
-const int imageExtensionCount = sizeof(imageExtensions) / sizeof(imageExtensions[0]);
+const int imageExtensionCount =
+	sizeof(imageExtensions) / sizeof(imageExtensions[0]);
 
 static int32_t xoffset = 0;
 static int32_t yoffset = 0;
@@ -41,10 +38,10 @@ static float fps;
 
 TFT_eSPI tft = TFT_eSPI(config.tftWidth, config.tftHeight);
 TFT_eSprite displayBuffer(&tft);
-const int displayBufferCount = config.getDisplayWidth() * config.getDisplayHeight();
+const int displayBufferCount =
+	config.getDisplayWidth() * config.getDisplayHeight();
 
-void setupDisplay()
-{
+void setupDisplay() {
 	Serial.println("Setting up display...");
 
 #if defined(TFT_BL)
@@ -69,8 +66,8 @@ void setupDisplay()
 	tft.startWrite();
 
 #if defined(TFT_BL)
-	delay(50); // Small delay to avoid garbage output
-	digitalWrite(TFT_BL, HIGH); // Turn backlight back on after init
+	delay(50);					 // Small delay to avoid garbage output
+	digitalWrite(TFT_BL, HIGH);	 // Turn backlight back on after init
 #endif
 
 	Serial.println("Display setup complete");
@@ -80,22 +77,20 @@ void setupDisplay()
  * Text and Graphics functions
  *******************************************************************************/
 
-inline void __attribute__((always_inline)) clearBuffer(TFT_eSprite *buffer = &displayBuffer)
-{
+inline void __attribute__((always_inline))
+clearBuffer(TFT_eSprite *buffer = &displayBuffer) {
 #if USE_DMA == 1
 	tft.dmaWait();
 #endif
 	buffer->deleteSprite();
 }
 
-inline void __attribute__((always_inline)) clearDisplay(void)
-{
+inline void __attribute__((always_inline)) clearDisplay(void) {
 	tft.fillScreen(config.backgroundColor);
 }
 
 // Draw various shapes on the screen and animate them for the specified duration
-void drawDemoShapes(int durationMS)
-{
+void drawDemoShapes(int durationMS) {
 #if defined(VERBOSE_OUTPUT) && VERBOSE_OUTPUT == 1
 	Serial.println("Demo shapes start");
 	long runtime = micros();
@@ -121,15 +116,22 @@ void drawDemoShapes(int durationMS)
 	bool reverse = false;
 
 	clearBuffer();
-	uint16_t *pixelBuf = (uint16_t *)displayBuffer.createSprite(config.getDisplayWidth(), config.getDisplayHeight());
+	uint16_t *pixelBuf = (uint16_t *)displayBuffer.createSprite(
+		config.getDisplayWidth(), config.getDisplayHeight());
 
-	while (millis() < endTime)
-	{
+	while (millis() < endTime) {
 		displayBuffer.fillScreen(TFT_BLACK);
-		displayBuffer.fillCircle(frame, displayWidth - frame, circleRadius, TFT_RED);
-		displayBuffer.fillRoundRect(displayWidth - (squareSize / 2) - frame, frame - (squareSize / 2), squareSize, squareSize, 3, TFT_GREEN);
-		displayBuffer.fillTriangle(frame, frame - triangleSize, frame - triangleSize, frame + triangleSize, frame + triangleSize, frame + triangleSize, TFT_BLUE);
-		displayBuffer.fillEllipse(displayWidth - frame, displayWidth - frame, ellipseRadiusX, ellipseRadiusY, TFT_YELLOW);
+		displayBuffer.fillCircle(frame, displayWidth - frame, circleRadius,
+								 TFT_RED);
+		displayBuffer.fillRoundRect(displayWidth - (squareSize / 2) - frame,
+									frame - (squareSize / 2), squareSize,
+									squareSize, 3, TFT_GREEN);
+		displayBuffer.fillTriangle(frame, frame - triangleSize,
+								   frame - triangleSize, frame + triangleSize,
+								   frame + triangleSize, frame + triangleSize,
+								   TFT_BLUE);
+		displayBuffer.fillEllipse(displayWidth - frame, displayWidth - frame,
+								  ellipseRadiusX, ellipseRadiusY, TFT_YELLOW);
 #if USE_DMA == 1
 		tft.dmaWait();
 		tft.pushImageDMA(0, 0, displayWidth, displayHeight, pixelBuf);
@@ -153,14 +155,15 @@ void drawDemoShapes(int durationMS)
 	}
 #if defined(VERBOSE_OUTPUT) && VERBOSE_OUTPUT == 1
 	runtime = micros() - runtime;
-	Serial.print("Demo random shapes at "); Serial.print(frames / (runtime / 1000000.0f)); Serial.println(" fps");
+	Serial.print("Demo random shapes at ");
+	Serial.print(frames / (runtime / 1000000.0f));
+	Serial.println(" fps");
 #endif
 	clearBuffer();
 }
 
 // Draws a transparent overlay on top of whatever is in the display buffer
-void overlayText(String text, TFT_eSPI *parent)
-{
+void overlayText(String text, TFT_eSPI *parent) {
 	int font = config.getFontSmall();
 	TFT_eSprite overlay(parent);
 	int width = tft.textWidth(text, font) + (DISPLAY_TEXT_MARGIN * 2);
@@ -172,66 +175,59 @@ void overlayText(String text, TFT_eSPI *parent)
 	overlay.drawString(text, DISPLAY_TEXT_MARGIN, DISPLAY_TEXT_MARGIN, font);
 #if USE_DMA == 1
 	tft.dmaWait();
-	tft.pushImageDMA((config.getDisplayWidth() - width) / 2, (config.getDisplayHeight() - height) / 2, width, height, pixelBuf);
+	tft.pushImageDMA((config.getDisplayWidth() - width) / 2,
+					 (config.getDisplayHeight() - height) / 2, width, height,
+					 pixelBuf);
 #else
-	overlay.pushSprite((config.getDisplayWidth() - width) / 2, (config.getDisplayHeight() - height) / 2);
+	overlay.pushSprite((config.getDisplayWidth() - width) / 2,
+					   (config.getDisplayHeight() - height) / 2);
 #endif
 	clearBuffer(&overlay);
 }
 
-void overlayText(String text)
-{
-	overlayText(text, &tft);
-}
+void overlayText(String text) { overlayText(text, &tft); }
 
 #if SHOW_FPS == 1
 // Show the last captured FPS value
-void showFPS(TFT_eSPI *parent)
-{
-	overlayText(String(fps), parent);
-}
+void showFPS(TFT_eSPI *parent) { overlayText(String(fps), parent); }
 
 // Show the last captured FPS value
-void showFPS(void)
-{
-	overlayText(String(fps), &tft);
-}
+void showFPS(void) { overlayText(String(fps), &tft); }
 
 // Show FPS by providing a new value
-void showFPS(float newFPS, TFT_eSPI *parent)
-{
+void showFPS(float newFPS, TFT_eSPI *parent) {
 	fps = newFPS;
 	overlayText(String(fps), parent);
 }
 
 // Show FPS by providing a new value
-void showFPS(float newFPS)
-{
+void showFPS(float newFPS) {
 	fps = newFPS;
 	overlayText(String(fps), &tft);
 }
 
 // Show FPS by providing the during in microseconds of the last frame
-void showFPS(unsigned long micros, TFT_eSPI *parent)
-{
+void showFPS(unsigned long micros, TFT_eSPI *parent) {
 	overlayText(String(1000000.0f / micros), parent);
 }
 
 // Show FPS by providing the during in microseconds of the last frame
-void showFPS(unsigned long micros)
-{
+void showFPS(unsigned long micros) {
 	overlayText(String(1000000.0f / micros), &tft);
 }
 #endif
 
-// Draw lines of text on the screen with center alignment horizontally and veritcally
-void showText(String lines[], int lineCount, uint8_t font, uint16_t textColor = TFT_WHITE, uint16_t backgroundColor = TFT_BLACK)
-{
+// Draw lines of text on the screen with center alignment horizontally and
+// veritcally
+void showText(String lines[], int lineCount, uint8_t font,
+			  uint16_t textColor = TFT_WHITE,
+			  uint16_t backgroundColor = TFT_BLACK) {
 	displayState = DISPLAY_STATIC_TEXT;
 
 	clearBuffer();
 
-	uint16_t *pixelBuf = (uint16_t *)displayBuffer.createSprite(config.getDisplayWidth(), config.getDisplayHeight());
+	uint16_t *pixelBuf = (uint16_t *)displayBuffer.createSprite(
+		config.getDisplayWidth(), config.getDisplayHeight());
 	displayBuffer.fillSprite(backgroundColor);
 	displayBuffer.setTextColor(textColor);
 	displayBuffer.setTextFont(font);
@@ -243,32 +239,37 @@ void showText(String lines[], int lineCount, uint8_t font, uint16_t textColor = 
 	int yStart = config.getMidpointY() - (lineCount / 2.0 * lineHeight);
 
 	for (int i = 0; i < lineCount; i++)
-		displayBuffer.drawCentreString(lines[i], midpointX, yStart + (i * lineHeight), font);
+		displayBuffer.drawCentreString(lines[i], midpointX,
+									   yStart + (i * lineHeight), font);
 
 #if USE_DMA == 1
 	tft.dmaWait();
-	tft.pushImageDMA(0, 0, config.getDisplayWidth(), config.getDisplayHeight(), pixelBuf);
+	tft.pushImageDMA(0, 0, config.getDisplayWidth(), config.getDisplayHeight(),
+					 pixelBuf);
 #else
 	displayBuffer.pushSprite(0, 0);
 #endif
 	clearBuffer();
 }
 
-// Draw lines of text on the screen with center alignment horizontally and veritcally
-void showText(String lines[], int lineCount, uint16_t textColor = TFT_WHITE, uint16_t backgroundColor = TFT_BLACK)
-{
-	showText(lines, lineCount, config.getFontLarge(), textColor, backgroundColor);
+// Draw lines of text on the screen with center alignment horizontally and
+// veritcally
+void showText(String lines[], int lineCount, uint16_t textColor = TFT_WHITE,
+			  uint16_t backgroundColor = TFT_BLACK) {
+	showText(lines, lineCount, config.getFontLarge(), textColor,
+			 backgroundColor);
 }
 
-// Draw a string of text on the screen with automatic word breaks, word wrap and center alignment horizontally and veritcally
-void showText(String text, uint8_t font, uint16_t textColor = TFT_WHITE, uint16_t backgroundColor = TFT_BLACK)
-{
+// Draw a string of text on the screen with automatic word breaks, word wrap and
+// center alignment horizontally and veritcally
+void showText(String text, uint8_t font, uint16_t textColor = TFT_WHITE,
+			  uint16_t backgroundColor = TFT_BLACK) {
 	// Get font properties
 	int fontHeight = tft.textWidth(" ", font);
 	int fontWidth = tft.fontHeight(font);
 
 	// Calculate text area parameters
-	int maxLineWidth = (config.getDisplayWidth() / 5) * 4; // Use 1/5 margin
+	int maxLineWidth = (config.getDisplayWidth() / 5) * 4;	// Use 1/5 margin
 	int startX = (config.getDisplayWidth() - maxLineWidth) / 2;
 	int charCount = text.length();
 	int charsPerLine = maxLineWidth / fontWidth;
@@ -279,15 +280,13 @@ void showText(String text, uint8_t font, uint16_t textColor = TFT_WHITE, uint16_
 	vector<String> words;
 	words.push_back("");
 
-	for (int c = 0; c < charCount; c++)
-	{
+	for (int c = 0; c < charCount; c++) {
 		char cc = text.charAt(c);
-		if (cc == ' ' && words[lineIndex].length() > 0)
-		{
+		if (cc == ' ' && words[lineIndex].length() > 0) {
 			words.push_back("");
 			lineIndex++;
-		}
-		else words[lineIndex] += cc;
+		} else
+			words[lineIndex] += cc;
 	}
 
 	// Align words to lines
@@ -298,8 +297,7 @@ void showText(String text, uint8_t font, uint16_t textColor = TFT_WHITE, uint16_
 	lines.push_back("");
 
 	// Iterate each word
-	for (String word : words)
-	{
+	for (String word : words) {
 		// Compute word width
 		wordWidth = 0;
 		wordCharCount = word.length();
@@ -307,44 +305,35 @@ void showText(String text, uint8_t font, uint16_t textColor = TFT_WHITE, uint16_
 			wordWidth += tft.textWidth(String(word.charAt(wc)), font);
 
 		// Will word (with space prefix) fit on line?
-		if ((lineWidth + spaceWidth + wordWidth) < maxLineWidth)
-		{
+		if ((lineWidth + spaceWidth + wordWidth) < maxLineWidth) {
 			// Append word (with space) to current line
 			lines[lineIndex] += " " + word;
 			lineWidth += (spaceWidth + wordWidth);
-		}
-		else
-		{
+		} else {
 			// Will word (without space prefix) fit on single full line?
-			if (wordWidth < maxLineWidth)
-			{
+			if (wordWidth < maxLineWidth) {
 				// Append word as new line
 				lines.push_back(word);
 				lineWidth = wordWidth;
 				lineIndex++;
-			}
-			else
-			{
-				// Take chars from beginning of temp string (plus '-') to max line width
+			} else {
+				// Take chars from beginning of temp string (plus '-') to max
+				// line width
 				int dashWidth = tft.textWidth("-", font);
 				lines.push_back("");
 				lineWidth = dashWidth;
 				wordCharCount = word.length();
 
-				for (int i = 0; i < wordCharCount; i++)
-				{
+				for (int i = 0; i < wordCharCount; i++) {
 					String wc = String(word.charAt(i));
 					charWidth = tft.textWidth(wc, font);
 
 					// Will temp char fit on the current line?
-					if ((charWidth + lineWidth) < maxLineWidth)
-					{
+					if ((charWidth + lineWidth) < maxLineWidth) {
 						// Append char to current line
 						lines[lineIndex] += wc;
 						lineWidth += charWidth;
-					}
-					else
-					{
+					} else {
 						// Finish current line and append char to new line
 						lines[lineIndex] += "-";
 						lines.push_back(wc);
@@ -359,20 +348,22 @@ void showText(String text, uint8_t font, uint16_t textColor = TFT_WHITE, uint16_
 	showText(lines.data(), lineIndex + 1, font, textColor, backgroundColor);
 }
 
-// Draw a string of text on the screen with automatic word breaks, word wrap and center alignment horizontally and veritcally
-void showText(String line, uint16_t textColor = TFT_WHITE, uint16_t backgroundColor = TFT_BLACK)
-{
+// Draw a string of text on the screen with automatic word breaks, word wrap and
+// center alignment horizontally and veritcally
+void showText(String line, uint16_t textColor = TFT_WHITE,
+			  uint16_t backgroundColor = TFT_BLACK) {
 	showText(line, config.getFontLarge(), textColor, backgroundColor);
 }
 
-// Draw "message box" style text with the first line being the header, and center alignment horizontally and veritcally for all text
-void showHeaderedText(String lines[], int lineCount)
-{
+// Draw "message box" style text with the first line being the header, and
+// center alignment horizontally and veritcally for all text
+void showHeaderedText(String lines[], int lineCount) {
 	displayState = DISPLAY_STATIC_TEXT;
 
 	clearBuffer();
 
-	uint16_t *pixelBuf = (uint16_t *)displayBuffer.createSprite(config.getDisplayWidth(), config.getDisplayHeight());
+	uint16_t *pixelBuf = (uint16_t *)displayBuffer.createSprite(
+		config.getDisplayWidth(), config.getDisplayHeight());
 	displayBuffer.fillSprite(TFT_BLACK);
 	displayBuffer.setTextColor(TFT_WHITE);
 
@@ -381,15 +372,19 @@ void showHeaderedText(String lines[], int lineCount)
 	int start = -(lineCount / 2) - (lineCount % 2);
 	int yOffset = 0;
 
-	for (int i = 0; i < lineCount; i++)
-	{
-		yOffset = ((i == 0) ? config.getFontLargeSize() : 0) + (-(i + start + 1) * config.getFontSmallSize()) + DISPLAY_TEXT_MARGIN;
-		displayBuffer.drawCentreString(lines[i], midpointX, midpointY - yOffset, (i == 0) ? config.getFontLarge() : config.getFontSmall());
+	for (int i = 0; i < lineCount; i++) {
+		yOffset = ((i == 0) ? config.getFontLargeSize() : 0) +
+				  (-(i + start + 1) * config.getFontSmallSize()) +
+				  DISPLAY_TEXT_MARGIN;
+		displayBuffer.drawCentreString(
+			lines[i], midpointX, midpointY - yOffset,
+			(i == 0) ? config.getFontLarge() : config.getFontSmall());
 	}
 
 #if USE_DMA == 1
 	tft.dmaWait();
-	tft.pushImageDMA(0, 0, config.getDisplayWidth(), config.getDisplayHeight(), pixelBuf);
+	tft.pushImageDMA(0, 0, config.getDisplayWidth(), config.getDisplayHeight(),
+					 pixelBuf);
 #else
 	displayBuffer.pushSprite(0, 0);
 #endif
@@ -397,13 +392,11 @@ void showHeaderedText(String lines[], int lineCount)
 }
 
 // Display a frame of the system information screen
-void showSystemInfo(uint32_t frameTime)
-{
+void showSystemInfo(uint32_t frameTime) {
 	static uint32_t nextFrameTime;
 
 	int32_t frameTimeDiff = frameTime - nextFrameTime;
-	if (frameTimeDiff < 0)
-		return;
+	if (frameTimeDiff < 0) return;
 
 	displayState = DISPLAY_SYSTEM_INFORMATION;
 
@@ -413,49 +406,50 @@ void showSystemInfo(uint32_t frameTime)
 	lines.push_back("v" + String(TTY2PICO_VERSION_STRING));
 	lines.push_back(TTY2PICO_BOARD);
 
-	snprintf(lineBuffer, sizeof(lineBuffer), "RP2040 @ %.1fMHz %.1fC", getCpuSpeedMHz(), getCpuTemperature());
+	snprintf(lineBuffer, sizeof(lineBuffer), "RP2040 @ %.1fMHz %.1fC",
+			 getCpuSpeedMHz(), getCpuTemperature());
 	lines.push_back(lineBuffer);
 
 	memset(lineBuffer, 0, sizeof(lineBuffer));
 	float displaySpi = getSpiRateDisplayMHz();
-	snprintf(lineBuffer, sizeof(lineBuffer), "%s @ %dx%d %.1fMHz", TTY2PICO_DISPLAY, config.getDisplayWidth(), config.getDisplayHeight(), displaySpi);
+	snprintf(lineBuffer, sizeof(lineBuffer), "%s @ %dx%d %.1fMHz",
+			 TTY2PICO_DISPLAY, config.getDisplayWidth(),
+			 config.getDisplayHeight(), displaySpi);
 	lines.push_back(lineBuffer);
 
 	lines.push_back(String(getTime(DTF_HUMAN)));
 
-	if (getHasSD())
-	{
+	if (getHasSD()) {
 		memset(lineBuffer, 0, sizeof(lineBuffer));
-		snprintf(lineBuffer, sizeof(lineBuffer), "SD Filesystem @ %.1fMHz", getSpiRateSdMHz());
+		snprintf(lineBuffer, sizeof(lineBuffer), "SD Filesystem @ %.1fMHz",
+				 getSpiRateSdMHz());
 		lines.push_back(lineBuffer);
-	}
-	else lines.push_back("Flash Filesystem");
+	} else
+		lines.push_back("Flash Filesystem");
 
 	showHeaderedText(lines.data(), lines.size());
 
-	nextFrameTime = frameTime + 1000; // Only update display once every second
+	nextFrameTime = frameTime + 1000;  // Only update display once every second
 }
 
 /*******************************************************************************
  * GIF
  *******************************************************************************/
 
-struct GIFDisplayOptions
-{
+struct GIFDisplayOptions {
 	bool loop;
 	bool uncap;
 };
-const GIFDisplayOptions GIF_ONCE      = { .loop = false, .uncap = false };
-const GIFDisplayOptions GIF_FAST      = { .loop = false, .uncap = true };
-const GIFDisplayOptions GIF_LOOP      = { .loop = true,  .uncap = false };
-const GIFDisplayOptions GIF_LOOP_FAST = { .loop = true,  .uncap = true };
+const GIFDisplayOptions GIF_ONCE = {.loop = false, .uncap = false};
+const GIFDisplayOptions GIF_FAST = {.loop = false, .uncap = true};
+const GIFDisplayOptions GIF_LOOP = {.loop = true, .uncap = false};
+const GIFDisplayOptions GIF_LOOP_FAST = {.loop = true, .uncap = true};
 static GIFDisplayOptions currentGifOption;
 
 // From the examples in the https://github.com/bitbank2/AnimatedGIF repo
 // Draw a line of image directly on the LCD
-[[deprecated("Replaced with gifDrawBufferedLine")]]
-static void gifDrawLine(GIFDRAW *pDraw)
-{
+[[deprecated("Replaced with gifDrawBufferedLine")]] static void gifDrawLine(
+	GIFDRAW *pDraw) {
 #if USE_DMA == 1
 	static uint16_t usTemp[2][TFT_DISPLAY_MAX];
 #else
@@ -473,60 +467,53 @@ static void gifDrawLine(GIFDRAW *pDraw)
 
 	// Display bounds check and cropping
 	iWidth = pDraw->iWidth;
-	if (iWidth + pDraw->iX > displayWidth)
-		iWidth = displayWidth - pDraw->iX;
+	if (iWidth + pDraw->iX > displayWidth) iWidth = displayWidth - pDraw->iX;
 	usPalette = pDraw->pPalette;
-	y = pDraw->iY + pDraw->y; // current line
-	if (y >= displayHeight || pDraw->iX >= displayWidth || iWidth < 1)
-		return;
+	y = pDraw->iY + pDraw->y;  // current line
+	if (y >= displayHeight || pDraw->iX >= displayWidth || iWidth < 1) return;
 
 	// Old image disposal
 	s = pDraw->pPixels;
-	if (pDraw->ucDisposalMethod == 2) // restore to background color
+	if (pDraw->ucDisposalMethod == 2)  // restore to background color
 	{
-		for (x = 0; x < iWidth; x++)
-		{
-			if (s[x] == pDraw->ucTransparent)
-				s[x] = pDraw->ucBackground;
+		for (x = 0; x < iWidth; x++) {
+			if (s[x] == pDraw->ucTransparent) s[x] = pDraw->ucBackground;
 		}
 		pDraw->ucHasTransparency = 0;
 	}
 
 	// Apply the new pixels to the main image
-	if (pDraw->ucHasTransparency) // if transparency used
+	if (pDraw->ucHasTransparency)  // if transparency used
 	{
 		uint8_t *pEnd, c, ucTransparent = pDraw->ucTransparent;
 		pEnd = s + iWidth;
 		x = 0;
-		iCount = 0; // count non-transparent pixels
-		while (x < iWidth)
-		{
+		iCount = 0;	 // count non-transparent pixels
+		while (x < iWidth) {
 			c = ucTransparent - 1;
 			d = &usTemp[dmaBuf][0];
-			while (c != ucTransparent && s < pEnd && iCount < TFT_DISPLAY_MAX)
-			{
+			while (c != ucTransparent && s < pEnd && iCount < TFT_DISPLAY_MAX) {
 				c = *s++;
-				if (c == ucTransparent) // done, stop
+				if (c == ucTransparent)	 // done, stop
 				{
-					s--; // back up to treat it like transparent
-				}
-				else // opaque
+					s--;  // back up to treat it like transparent
+				} else	  // opaque
 				{
 					*d++ = usPalette[c];
 					iCount++;
 				}
-			} // while looking for opaque pixels
-			if (iCount) // any opaque pixels?
+			}			 // while looking for opaque pixels
+			if (iCount)	 // any opaque pixels?
 			{
-				tft.setAddrWindow(pDraw->iX + x + xoffset, y + yoffset, iCount, 1);
+				tft.setAddrWindow(pDraw->iX + x + xoffset, y + yoffset, iCount,
+								  1);
 				tft.pushPixels(&usTemp[dmaBuf][0], iCount);
 				x += iCount;
 				iCount = 0;
 			}
 			// no, look for a run of transparent pixels
 			c = ucTransparent;
-			while (c == ucTransparent && s < pEnd)
-			{
+			while (c == ucTransparent && s < pEnd) {
 				c = *s++;
 				if (c == ucTransparent)
 					x++;
@@ -534,16 +521,15 @@ static void gifDrawLine(GIFDRAW *pDraw)
 					s--;
 			}
 		}
-	}
-	else
-	{
+	} else {
 		s = pDraw->pPixels;
 
 		tft.setAddrWindow(pDraw->iX + xoffset, y + yoffset, iWidth, 1);
 
 #if USE_DMA == 1
 		// Unroll the first pass to boost DMA performance
-		// Translate the 8-bit pixels through the RGB565 palette (already byte reversed)
+		// Translate the 8-bit pixels through the RGB565 palette (already byte
+		// reversed)
 		if (iWidth <= TFT_DISPLAY_MAX)
 			for (iCount = 0; iCount < iWidth; iCount++)
 				usTemp[dmaBuf][iCount] = usPalette[*s++];
@@ -562,13 +548,15 @@ static void gifDrawLine(GIFDRAW *pDraw)
 
 		iWidth -= iCount;
 		// Loop if pixel buffer smaller than width
-		while (iWidth > 0)
-		{
-			// Translate the 8-bit pixels through the RGB565 palette (already byte reversed)
+		while (iWidth > 0) {
+			// Translate the 8-bit pixels through the RGB565 palette (already
+			// byte reversed)
 			if (iWidth <= TFT_DISPLAY_MAX)
-				for (iCount = 0; iCount < iWidth; iCount++) usTemp[dmaBuf][iCount] = usPalette[*s++];
+				for (iCount = 0; iCount < iWidth; iCount++)
+					usTemp[dmaBuf][iCount] = usPalette[*s++];
 			else
-				for (iCount = 0; iCount < TFT_DISPLAY_MAX; iCount++) usTemp[dmaBuf][iCount] = usPalette[*s++];
+				for (iCount = 0; iCount < TFT_DISPLAY_MAX; iCount++)
+					usTemp[dmaBuf][iCount] = usPalette[*s++];
 
 #if USE_DMA == 1
 			tft.dmaWait();
@@ -583,8 +571,7 @@ static void gifDrawLine(GIFDRAW *pDraw)
 	}
 }
 
-static void gifDrawBufferedLine(GIFDRAW *pDraw)
-{
+static void gifDrawBufferedLine(GIFDRAW *pDraw) {
 	static uint16_t usTemp[TFT_DISPLAY_MAX];
 
 	int displayWidth = config.getDisplayWidth();
@@ -596,59 +583,52 @@ static void gifDrawBufferedLine(GIFDRAW *pDraw)
 
 	// Display bounds check and cropping
 	iWidth = pDraw->iWidth;
-	if (iWidth + pDraw->iX > displayWidth)
-		iWidth = displayWidth - pDraw->iX;
+	if (iWidth + pDraw->iX > displayWidth) iWidth = displayWidth - pDraw->iX;
 	usPalette = pDraw->pPalette;
-	y = pDraw->iY + pDraw->y; // current line
-	if (y >= displayHeight || pDraw->iX >= displayWidth || iWidth < 1)
-		return;
+	y = pDraw->iY + pDraw->y;  // current line
+	if (y >= displayHeight || pDraw->iX >= displayWidth || iWidth < 1) return;
 
 	// Old image disposal
 	s = pDraw->pPixels;
-	if (pDraw->ucDisposalMethod == 2) // restore to background color
+	if (pDraw->ucDisposalMethod == 2)  // restore to background color
 	{
-		for (x = 0; x < iWidth; x++)
-		{
-			if (s[x] == pDraw->ucTransparent)
-				s[x] = pDraw->ucBackground;
+		for (x = 0; x < iWidth; x++) {
+			if (s[x] == pDraw->ucTransparent) s[x] = pDraw->ucBackground;
 		}
 		pDraw->ucHasTransparency = 0;
 	}
 
 	// Apply the new pixels to the main image
-	if (pDraw->ucHasTransparency) // if transparency used
+	if (pDraw->ucHasTransparency)  // if transparency used
 	{
 		uint8_t *pEnd, c, ucTransparent = pDraw->ucTransparent;
 		pEnd = s + iWidth;
 		x = 0;
-		iCount = 0; // count non-transparent pixels
-		while (x < iWidth)
-		{
+		iCount = 0;	 // count non-transparent pixels
+		while (x < iWidth) {
 			c = ucTransparent - 1;
 			d = &usTemp[0];
-			while (c != ucTransparent && s < pEnd && iCount < TFT_DISPLAY_MAX)
-			{
+			while (c != ucTransparent && s < pEnd && iCount < TFT_DISPLAY_MAX) {
 				c = *s++;
-				if (c == ucTransparent) // done, stop
+				if (c == ucTransparent)	 // done, stop
 				{
-					s--; // back up to treat it like transparent
-				}
-				else // opaque
+					s--;  // back up to treat it like transparent
+				} else	  // opaque
 				{
 					*d++ = usPalette[c];
 					iCount++;
 				}
-			} // while looking for opaque pixels
-			if (iCount) // any opaque pixels?
+			}			 // while looking for opaque pixels
+			if (iCount)	 // any opaque pixels?
 			{
-				displayBuffer.pushImage(pDraw->iX + x + xoffset, y + yoffset, iCount, 1, &usTemp[0]);
+				displayBuffer.pushImage(pDraw->iX + x + xoffset, y + yoffset,
+										iCount, 1, &usTemp[0]);
 				x += iCount;
 				iCount = 0;
 			}
 			// no, look for a run of transparent pixels
 			c = ucTransparent;
-			while (c == ucTransparent && s < pEnd)
-			{
+			while (c == ucTransparent && s < pEnd) {
 				c = *s++;
 				if (c == ucTransparent)
 					x++;
@@ -656,14 +636,13 @@ static void gifDrawBufferedLine(GIFDRAW *pDraw)
 					s--;
 			}
 		}
-	}
-	else
-	{
+	} else {
 		s = pDraw->pPixels;
 
 #if USE_DMA == 1
 		// Unroll the first pass to boost DMA performance
-		// Translate the 8-bit pixels through the RGB565 palette (already byte reversed)
+		// Translate the 8-bit pixels through the RGB565 palette (already byte
+		// reversed)
 		if (iWidth <= TFT_DISPLAY_MAX)
 			for (iCount = 0; iCount < iWidth; iCount++)
 				usTemp[iCount] = usPalette[*s++];
@@ -672,26 +651,29 @@ static void gifDrawBufferedLine(GIFDRAW *pDraw)
 				usTemp[iCount] = usPalette[*s++];
 #endif
 
-		displayBuffer.pushImage(pDraw->iX + xoffset, y + yoffset, iWidth, 1, &usTemp[0]);
+		displayBuffer.pushImage(pDraw->iX + xoffset, y + yoffset, iWidth, 1,
+								&usTemp[0]);
 
 		iWidth -= iCount;
 		// Loop if pixel buffer smaller than width
-		while (iWidth > 0)
-		{
-			// Translate the 8-bit pixels through the RGB565 palette (already byte reversed)
+		while (iWidth > 0) {
+			// Translate the 8-bit pixels through the RGB565 palette (already
+			// byte reversed)
 			if (iWidth <= TFT_DISPLAY_MAX)
-				for (iCount = 0; iCount < iWidth; iCount++) usTemp[iCount] = usPalette[*s++];
+				for (iCount = 0; iCount < iWidth; iCount++)
+					usTemp[iCount] = usPalette[*s++];
 			else
-				for (iCount = 0; iCount < TFT_DISPLAY_MAX; iCount++) usTemp[iCount] = usPalette[*s++];
+				for (iCount = 0; iCount < TFT_DISPLAY_MAX; iCount++)
+					usTemp[iCount] = usPalette[*s++];
 
-			displayBuffer.pushImage(pDraw->iX + xoffset, y + yoffset, iWidth, 1, &usTemp[0]);
+			displayBuffer.pushImage(pDraw->iX + xoffset, y + yoffset, iWidth, 1,
+									&usTemp[0]);
 
 			iWidth -= iCount;
 		}
 	}
 
-	if (y == pDraw->iHeight - 1)
-	{
+	if (y == pDraw->iHeight - 1) {
 #if USE_DMA == 1
 		tft.dmaWait();
 		tft.pushPixelsDMA((uint16_t *)pDraw->pUser, displayBufferCount);
@@ -701,16 +683,17 @@ static void gifDrawBufferedLine(GIFDRAW *pDraw)
 	}
 }
 
-static inline void displayGIF(AnimatedGIF *gif, GIFDisplayOptions options)
-{
+static inline void displayGIF(AnimatedGIF *gif, GIFDisplayOptions options) {
 	int displayWidth = config.getDisplayWidth();
 	int displayHeight = config.getDisplayHeight();
 	xoffset = (displayWidth - gif->getCanvasWidth()) / 2;
 	yoffset = (displayHeight - gif->getCanvasHeight()) / 2;
-	displayState = options.loop ? DISPLAY_ANIMATED_GIF_LOOPING : DISPLAY_ANIMATED_GIF;
+	displayState =
+		options.loop ? DISPLAY_ANIMATED_GIF_LOOPING : DISPLAY_ANIMATED_GIF;
 
 	clearBuffer();
-	uint16_t *pixelBuf = (uint16_t *)displayBuffer.createSprite(config.getDisplayWidth(), config.getDisplayHeight());
+	uint16_t *pixelBuf = (uint16_t *)displayBuffer.createSprite(
+		config.getDisplayWidth(), config.getDisplayHeight());
 	displayBuffer.fillSprite(config.backgroundColor);
 
 #if SHOW_FPS == 1 || VERBOSE_OUTPUT == 1
@@ -721,8 +704,8 @@ static inline void displayGIF(AnimatedGIF *gif, GIFDisplayOptions options)
 	unsigned long frameStart = micros();
 #endif
 
-	while (gif->playFrame(!(options.uncap || config.uncapFramerate), NULL, pixelBuf))
-	{
+	while (gif->playFrame(!(options.uncap || config.uncapFramerate), NULL,
+						  pixelBuf)) {
 #if SHOW_FPS == 1
 		showFPS(micros() - frameStart);
 #endif
@@ -738,8 +721,7 @@ static inline void displayGIF(AnimatedGIF *gif, GIFDisplayOptions options)
 #if SHOW_FPS == 1 || VERBOSE_OUTPUT == 1
 	unsigned long runStop = micros();
 #endif
-	if (gif->getLastError() == GIF_SUCCESS)
-	{
+	if (gif->getLastError() == GIF_SUCCESS) {
 #if SHOW_FPS == 1
 		showFPS(runStop - frameStart);
 #endif
@@ -749,51 +731,54 @@ static inline void displayGIF(AnimatedGIF *gif, GIFDisplayOptions options)
 	}
 
 #if VERBOSE_OUTPUT == 1
-	Serial.print("Ran GIF at "); Serial.print(frames / ((runStop - runStart) / 1000000.0f)); Serial.println(" fps");
+	Serial.print("Ran GIF at ");
+	Serial.print(frames / ((runStop - runStart) / 1000000.0f));
+	Serial.println(" fps");
 #endif
 	clearBuffer();
 }
 
-static void showGIF(uint8_t *data, int size, GIFDisplayOptions options)
-{
+static void showGIF(uint8_t *data, int size, GIFDisplayOptions options) {
 	AnimatedGIF gif;
 	gif.begin(BIG_ENDIAN_PIXELS);
 
-	if (gif.open(data, size, gifDrawBufferedLine))
-	{
+	if (gif.open(data, size, gifDrawBufferedLine)) {
 #if VERBOSE_OUTPUT == 1
-	Serial.print("Opened streamed GIF with resolution "); Serial.print(gif.getCanvasWidth()); Serial.print(" x "); Serial.println(gif.getCanvasHeight());
+		Serial.print("Opened streamed GIF with resolution ");
+		Serial.print(gif.getCanvasWidth());
+		Serial.print(" x ");
+		Serial.println(gif.getCanvasHeight());
 #endif
 		displayGIF(&gif, options);
 		gif.close();
-	}
-	else
-	{
+	} else {
 		Serial.println("Could not open GIF from RAM");
 	}
 }
 
-static void showGIF(const char *path, GIFDisplayOptions options)
-{
+static void showGIF(const char *path, GIFDisplayOptions options) {
 	AnimatedGIF gif;
 	gif.begin(BIG_ENDIAN_PIXELS);
 
-	if (gif.open(path, gifOpen, gifClose, gifRead, gifSeek, gifDrawBufferedLine))
-	{
+	if (gif.open(path, gifOpen, gifClose, gifRead, gifSeek,
+				 gifDrawBufferedLine)) {
 #if VERBOSE_OUTPUT == 1
-	Serial.print("Opened GIF "); Serial.print(path); Serial.print(" with resolution "); Serial.print(gif.getCanvasWidth()); Serial.print(" x "); Serial.println(gif.getCanvasHeight());
+		Serial.print("Opened GIF ");
+		Serial.print(path);
+		Serial.print(" with resolution ");
+		Serial.print(gif.getCanvasWidth());
+		Serial.print(" x ");
+		Serial.println(gif.getCanvasHeight());
 #endif
 		displayGIF(&gif, options);
 		gif.close();
-	}
-	else
-	{
-		Serial.print("Could not open GIF "); Serial.println(path);
+	} else {
+		Serial.print("Could not open GIF ");
+		Serial.println(path);
 	}
 }
 
-static void showGIF(String path, GIFDisplayOptions options)
-{
+static void showGIF(String path, GIFDisplayOptions options) {
 	showGIF(path.c_str(), options);
 }
 
@@ -801,18 +786,21 @@ static void showGIF(String path, GIFDisplayOptions options)
  * PNG
  *******************************************************************************/
 
-#define TFT_TRANSPARENT_8BPP ((uint8_t)((TFT_TRANSPARENT & 0xE000)>>8 | (TFT_TRANSPARENT & 0x0700)>>6 | (TFT_TRANSPARENT & 0x0018)>>3))
+#define TFT_TRANSPARENT_8BPP                     \
+	((uint8_t)((TFT_TRANSPARENT & 0xE000) >> 8 | \
+			   (TFT_TRANSPARENT & 0x0700) >> 6 | \
+			   (TFT_TRANSPARENT & 0x0018) >> 3))
 
-static void pngDrawLine(PNGDRAW *pDraw)
-{
+static void pngDrawLine(PNGDRAW *pDraw) {
 	uint16_t lineBuffer[TFT_DISPLAY_MAX];
 	PNG *png = ((PNG *)pDraw->pUser);
-	png->getLineAsRGB565(pDraw, lineBuffer, PNG_RGB565_BIG_ENDIAN, tft.color16to24(config.backgroundColor));
-	displayBuffer.pushImage(xoffset, pDraw->y + yoffset, pDraw->iWidth, 1, lineBuffer, TFT_TRANSPARENT_8BPP);
+	png->getLineAsRGB565(pDraw, lineBuffer, PNG_RGB565_BIG_ENDIAN,
+						 tft.color16to24(config.backgroundColor));
+	displayBuffer.pushImage(xoffset, pDraw->y + yoffset, pDraw->iWidth, 1,
+							lineBuffer, TFT_TRANSPARENT_8BPP);
 }
 
-static inline void displayPNG(PNG &png)
-{
+static inline void displayPNG(PNG &png) {
 	displayState = DISPLAY_STATIC_IMAGE;
 
 	int width = png.getWidth();
@@ -823,22 +811,32 @@ static inline void displayPNG(PNG &png)
 	yoffset = (displayHeight - height) / 2;
 
 	clearBuffer();
-	uint16_t *pixelBuf = (uint16_t *)displayBuffer.createSprite(displayWidth, displayHeight);
+	uint16_t *pixelBuf =
+		(uint16_t *)displayBuffer.createSprite(displayWidth, displayHeight);
 	displayBuffer.fillSprite(config.backgroundColor);
 
-	png.decode(NULL, 0); // Fill displayBuffer sprite with image data
+	png.decode(NULL, 0);  // Fill displayBuffer sprite with image data
 
-	if ((width < displayWidth || height < displayHeight) && !png.hasAlpha())
-	{
-		// When PNG is smaller than display and not transparent use the top-left pixel of the image for background
+	if ((width < displayWidth || height < displayHeight) && !png.hasAlpha()) {
+		// When PNG is smaller than display and not transparent use the top-left
+		// pixel of the image for background
 		uint32_t topLeftColor = displayBuffer.readPixel(xoffset, yoffset);
 #if VERBOSE_OUTPUT == 1
-		Serial.print("Filling screen with "); Serial.println(topLeftColor, HEX);
+		Serial.print("Filling screen with ");
+		Serial.println(topLeftColor, HEX);
 #endif
-		displayBuffer.fillRect(0, 0, displayWidth, yoffset, topLeftColor); // Top space
-		displayBuffer.fillRect(0, (displayHeight - height) / 2, (displayWidth - width) / 2, displayHeight - ((displayHeight - height) / 2), topLeftColor); // Left space
-		displayBuffer.fillRect(xoffset + width, (displayHeight - height) / 2, displayWidth - (displayWidth - width / 2), displayHeight - ((displayHeight - height) / 2), topLeftColor); // Right space
-		displayBuffer.fillRect(0, height + yoffset, displayWidth, displayHeight, topLeftColor); // Bottom space
+		displayBuffer.fillRect(0, 0, displayWidth, yoffset,
+							   topLeftColor);  // Top space
+		displayBuffer.fillRect(0, (displayHeight - height) / 2,
+							   (displayWidth - width) / 2,
+							   displayHeight - ((displayHeight - height) / 2),
+							   topLeftColor);  // Left space
+		displayBuffer.fillRect(xoffset + width, (displayHeight - height) / 2,
+							   displayWidth - (displayWidth - width / 2),
+							   displayHeight - ((displayHeight - height) / 2),
+							   topLeftColor);  // Right space
+		displayBuffer.fillRect(0, height + yoffset, displayWidth, displayHeight,
+							   topLeftColor);  // Bottom space
 	}
 
 #if USE_DMA == 1
@@ -850,129 +848,112 @@ static inline void displayPNG(PNG &png)
 	clearBuffer();
 }
 
-static void showPNG(uint8_t *data, int size)
-{
+static void showPNG(uint8_t *data, int size) {
 	PNG png;
-	if (png.openRAM(data, size, pngDrawLine) == PNG_SUCCESS)
-	{
+	if (png.openRAM(data, size, pngDrawLine) == PNG_SUCCESS) {
 #if VERBOSE_OUTPUT == 1
-		Serial.print("Opened streamed PNG with resolution "); Serial.print(png.getWidth()); Serial.print("x"); Serial.println(png.getHeight());
+		Serial.print("Opened streamed PNG with resolution ");
+		Serial.print(png.getWidth());
+		Serial.print("x");
+		Serial.println(png.getHeight());
 #endif
 		displayPNG(png);
 		png.close();
-	}
-	else
-	{
+	} else {
 		Serial.print("Could not open PNG from RAM");
 	}
 }
 
-static void showPNG(const char *path)
-{
+static void showPNG(const char *path) {
 	PNG png;
-	if (png.open(path, pngOpen, pngClose, pngRead, pngSeek, pngDrawLine) == PNG_SUCCESS)
-	{
+	if (png.open(path, pngOpen, pngClose, pngRead, pngSeek, pngDrawLine) ==
+		PNG_SUCCESS) {
 #if VERBOSE_OUTPUT == 1
-		Serial.print("Opened PNG "); Serial.print(path); Serial.print(" with resolution "); Serial.print(png.getWidth()); Serial.print("x"); Serial.println(png.getHeight());
+		Serial.print("Opened PNG ");
+		Serial.print(path);
+		Serial.print(" with resolution ");
+		Serial.print(png.getWidth());
+		Serial.print("x");
+		Serial.println(png.getHeight());
 #endif
 		displayPNG(png);
 		png.close();
-	}
-	else
-	{
-		Serial.print("Could not open PNG "); Serial.println(path);
+	} else {
+		Serial.print("Could not open PNG ");
+		Serial.println(path);
 	}
 }
 
-void showPNG(String path)
-{
-	showPNG(path.c_str());
-}
+void showPNG(String path) { showPNG(path.c_str()); }
 
 /*******************************************************************************
  * Generic functions
  *******************************************************************************/
 
-DisplayState getDisplayState(void)
-{
-	return displayState;
-}
+DisplayState getDisplayState(void) { return displayState; }
 
-void setDisplayState(DisplayState state)
-{
-	displayState = state;
-}
+void setDisplayState(DisplayState state) { displayState = state; }
 
-void showImage(const char *path)
-{
+void showImage(const char *path) {
 #if VERBOSE_OUTPUT == 1
-	Serial.print("Showing image: "); Serial.println(path);
+	Serial.print("Showing image: ");
+	Serial.println(path);
 #endif
-	if (fileExists(path))
-	{
+	if (fileExists(path)) {
 		currentImage = String(path);
 		currentImage.trim();
 		currentImage.toLowerCase();
 
 		bool found = false;
-		for (int i = 0; i < imageExtensionCount; i++)
-		{
-			if (currentImage.endsWith(imageExtensions[i]))
-			{
-				currentGifOption.loop  = currentImage.indexOf(".loop") > -1;
+		for (int i = 0; i < imageExtensionCount; i++) {
+			if (currentImage.endsWith(imageExtensions[i])) {
+				currentGifOption.loop = currentImage.indexOf(".loop") > -1;
 				currentGifOption.uncap = currentImage.indexOf(".fast") > -1;
 				found = true;
 				break;
 			}
 		}
 
-		if (found)
-		{
+		if (found) {
 			if (currentImage.endsWith(".gif"))
 				showGIF(path, currentGifOption);
 			else if (currentImage.endsWith(".png"))
 				showPNG(path);
-		}
-		else
-		{
+		} else {
 			currentImage = "";
 			showText(path);
 		}
-	}
-	else showText(path);
+	} else
+		showText(path);
 }
 
-void showImage(String path)
-{
-	showImage(path.c_str());
-}
+void showImage(String path) { showImage(path.c_str()); }
 
-void showMister(void)
-{
+void showMister(void) {
 	showGIF((uint8_t *)mister_kun_blink, sizeof(mister_kun_blink), GIF_LOOP);
-	displayState = DISPLAY_MISTER; // Explicitly set display state since the displayGIF() method set it
+	displayState = DISPLAY_MISTER;	// Explicitly set display state since the
+									// displayGIF() method set it
 }
 
-void showStartup(void)
-{
-	if (config.startupCommand != "")
-	{
+void showStartupImage(void) {
+	if (config.startupImage == "")
+		showMister();
+	else
+		showImage(config.startupImage);
+}
+
+void showStartup(void) {
+	if (config.startupCommand != "") {
 		CommandData command = CommandData::parseCommand(config.startupCommand);
 		addToQueue(command);
-	}
-	else
-	{
+	} else {
 		int64_t end = millis() + config.startupDelay;
-		while (millis() - end < 0)
-		{
+		while (millis() - end < 0) {
 			showSystemInfo(millis());
 			yield();
 		}
 
-		if (config.startupImage == "")
-			showMister();
-		else
-			showImage(config.startupImage);
+		showStartupImage();
 	}
 }
 
@@ -980,29 +961,28 @@ void showStartup(void)
  * Slideshow functions
  *******************************************************************************/
 
-static void runSlideshow(uint32_t time)
-{
+static void runSlideshow(uint32_t time) {
 	static uint32_t nextChange = 0;
 
-	if (time < nextChange)
-		return;
+	if (time < nextChange) return;
 
 	String nextFile = getNextFile();
-	if (nextFile == "")
-	{
+	if (nextFile == "") {
 		const char *dirName = getDirectory().c_str();
 #if VERBOSE_OUTPUT == 1
-		Serial.print("No slideshow file found, reset directory for: "); Serial.println(dirName);
+		Serial.print("No slideshow file found, reset directory for: ");
+		Serial.println(dirName);
 #endif
 		rewindDirectory();
-	}
-	else
-	{
+	} else {
 #if VERBOSE_OUTPUT == 1
-		Serial.print("Found slideshow file: "); Serial.println(nextFile.c_str());
+		Serial.print("Found slideshow file: ");
+		Serial.println(nextFile.c_str());
 #endif
 		showImage(nextFile);
-		displayState = DISPLAY_SLIDESHOW; // Need to explicitly set state here since showImage methods will update it
+		displayState =
+			DISPLAY_SLIDESHOW;	// Need to explicitly set state here since
+								// showImage methods will update it
 		nextChange = time + config.slideshowDelay;
 	}
 }
@@ -1011,15 +991,22 @@ static void runSlideshow(uint32_t time)
  * Lifecycle functions
  *******************************************************************************/
 
-void loopDisplay(uint32_t time)
-{
-	switch (displayState)
-	{
-		case DISPLAY_ANIMATED_GIF_LOOPING: showGIF(currentImage, currentGifOption); break;
-		case DISPLAY_SLIDESHOW:            runSlideshow(time);                      break;
-		case DISPLAY_SYSTEM_INFORMATION:   showSystemInfo(time);                    break;
-		case DISPLAY_MISTER:               showMister();                            break;
-		default:                                                                    break;
+void loopDisplay(uint32_t time) {
+	switch (displayState) {
+		case DISPLAY_ANIMATED_GIF_LOOPING:
+			showGIF(currentImage, currentGifOption);
+			break;
+		case DISPLAY_SLIDESHOW:
+			runSlideshow(time);
+			break;
+		case DISPLAY_SYSTEM_INFORMATION:
+			showSystemInfo(time);
+			break;
+		case DISPLAY_MISTER:
+			showMister();
+			break;
+		default:
+			break;
 	}
 }
 

--- a/arduino/tty2pico/include/storage.h
+++ b/arduino/tty2pico/include/storage.h
@@ -1,7 +1,7 @@
 #ifndef STORAGE_H
 #define STORAGE_H
 
-#define FS_BLOCK_SIZE 512 // Always use 512k block size
+#define FS_BLOCK_SIZE 512  // Always use 512k block size
 
 // Makes PlatformIO intellisense happy
 #ifdef SD_FAT_TYPE
@@ -25,19 +25,22 @@
 // #define FLASHFS_CUSTOM_SPI  SPI
 
 #if defined(FLASHFS_CUSTOM_CS) && defined(FLASHFS_CUSTOM_SPI)
-	Adafruit_FlashTransport_SPI flashTransport(FLASHFS_CUSTOM_CS, FLASHFS_CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(FLASHFS_CUSTOM_CS,
+										   FLASHFS_CUSTOM_SPI);
 #elif defined(ARDUINO_ARCH_ESP32)
-	Adafruit_FlashTransport_ESP32 flashTransport;
+Adafruit_FlashTransport_ESP32 flashTransport;
 #elif defined(ARDUINO_ARCH_RP2040)
-	Adafruit_FlashTransport_RP2040 flashTransport((1 * 1024 * RESERVED_FLASH_KB), 0);
+Adafruit_FlashTransport_RP2040 flashTransport((1 * 1024 * RESERVED_FLASH_KB),
+											  0);
 #else
-	#if defined(EXTERNAL_FLASH_USE_QSPI)
-		Adafruit_FlashTransport_QSPI flashTransport;
-	#elif defined(EXTERNAL_FLASH_USE_SPI)
-		Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-	#else
-		#error No QSPI/SPI flash are defined on your board variant.h !
-	#endif
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+										   EXTERNAL_FLASH_USE_SPI);
+#else
+#error No QSPI/SPI flash are defined on your board variant.h !
+#endif
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);
@@ -49,7 +52,7 @@ SdFs sdfs;
 static bool hasSD = false;
 bool sdfsChanged;
 
-FsVolumeTS volume; // Pointer to the active volume
+FsVolumeTS volume;	// Pointer to the active volume
 
 uint8_t workbuf[4096];
 FATFS fatfs;
@@ -58,13 +61,11 @@ FATFS fatfs;
  * Helper functions
  *************************/
 
-bool checkSD()
-{
+bool checkSD() {
 	pauseBackground();
 	FsFile tmp = sdfs.open("/tty2pico.tmp", O_RDWR | O_CREAT | O_AT_END);
 	bool exists = tmp;
-	if (exists)
-		tmp.remove();
+	if (exists) tmp.remove();
 	tmp.close();
 	sdfs.card()->syncDevice();
 	resumeBackground();
@@ -72,10 +73,11 @@ bool checkSD()
 	return exists;
 }
 
-// Since SdFat won't format anything smaller than 6MB use Elm Cham's fatfs f_mkfs() to format
-void formatFlash(void)
-{
-	// This is mostly copy/pasta of the example code for formatting using the FatFs lib:
+// Since SdFat won't format anything smaller than 6MB use Elm Cham's fatfs
+// f_mkfs() to format
+void formatFlash(void) {
+	// This is mostly copy/pasta of the example code for formatting using the
+	// FatFs lib:
 	// https://github.com/adafruit/Adafruit_SPIFlash/blob/master/examples/SdFat_format/SdFat_format.ino
 
 	// Call fatfs begin and passed flash object to initialize filesystem
@@ -83,84 +85,79 @@ void formatFlash(void)
 
 	// Make filesystem.
 	FRESULT r = f_mkfs("", FM_FAT | FM_SFD, 0, workbuf, sizeof(workbuf));
-	if (r != FR_OK)
-	{
-		Serial.print("Error, f_mkfs failed with error code: "); Serial.println(r, DEC);
-		while(1) yield();
+	if (r != FR_OK) {
+		Serial.print("Error, f_mkfs failed with error code: ");
+		Serial.println(r, DEC);
+		while (1) yield();
 	}
 
 	Serial.println("Filesystem created, attempting to mount");
 
 	r = f_mount(&fatfs, "0:", 1);
-	if (r != FR_OK)
-	{
-		Serial.print("Error, f_mount failed with error code: "); Serial.println(r, DEC);
-		while(1) yield();
+	if (r != FR_OK) {
+		Serial.print("Error, f_mount failed with error code: ");
+		Serial.println(r, DEC);
+		while (1) yield();
 	}
 
 	Serial.println("Setting disk label to: " DISK_LABEL);
 
 	r = f_setlabel(DISK_LABEL);
-	if (r != FR_OK)
-	{
-		Serial.print("Error, f_setlabel failed with error code: "); Serial.println(r, DEC);
-		while(1) yield();
+	if (r != FR_OK) {
+		Serial.print("Error, f_setlabel failed with error code: ");
+		Serial.println(r, DEC);
+		while (1) yield();
 	}
 
 	f_unmount("0:");
 
-	flash.syncDevice(); // sync to make sure all data is written to flash
+	flash.syncDevice();	 // sync to make sure all data is written to flash
 
 	Serial.println("Formatted flash!");
 }
 
-FsFileTS getFile(const char *path, oflag_t oflag = O_RDONLY)
-{
+FsFileTS getFile(const char *path, oflag_t oflag = O_RDONLY) {
 	FsFileTS file = volume.open(path, oflag);
 #if VERBOSE_OUTPUT == 1
-	if (file)
-	{
-		Serial.print("Opened file: "); Serial.println(path);
-	}
-	else
-	{
-		Serial.print("Couldn't open file: "); Serial.print(path); Serial.print(", error code: "); Serial.println(file.getError());
+	if (file) {
+		Serial.print("Opened file: ");
+		Serial.println(path);
+	} else {
+		Serial.print("Couldn't open file: ");
+		Serial.print(path);
+		Serial.print(", error code: ");
+		Serial.println(file.getError());
 	}
 #endif
 
 	return file;
 }
 
-FsFileTS getFile(String path, oflag_t oflag = O_RDONLY)
-{
+FsFileTS getFile(String path, oflag_t oflag = O_RDONLY) {
 	return getFile(path.c_str(), oflag);
 }
 
-bool getHasSD(void)
-{
-	return hasSD;
-}
+bool getHasSD(void) { return hasSD; }
 
-bool saveFile(String path, const char *data, int size, oflag_t oflag = O_RDWR | O_CREAT | O_AT_END)
-{
+bool saveFile(String path, const char *data, int size,
+			  oflag_t oflag = O_RDWR | O_CREAT | O_AT_END) {
 	FsFileTS file = getFile(path, oflag);
-	if (!file)
-	{
-		Serial.print("Unable to open file during save "); Serial.println(path);
+	if (!file) {
+		Serial.print("Unable to open file during save ");
+		Serial.println(path);
 		file.close();
 		return false;
 	}
 
 	size_t bytes = file.write(data, size);
-	if (bytes)
-	{
+	if (bytes) {
 #if VERBOSE_OUTPUT == 1
-		Serial.print("Saved file "); Serial.println(path);
+		Serial.print("Saved file ");
+		Serial.println(path);
 #endif
-	}
-	else
-	{
-		Serial.print("Failed to save file "); Serial.println(path);
+	} else {
+		Serial.print("Failed to save file ");
+		Serial.println(path);
 	}
 	file.close(true);
 
@@ -171,23 +168,21 @@ bool saveFile(String path, const char *data, int size, oflag_t oflag = O_RDWR | 
  * Setup functions
  *************************/
 
-void saveConfig(void)
-{
-	int bufferSize = 4096; // Allocate 4K buffer to handle config data
+void saveConfig(void) {
+	int bufferSize = 4096;	// Allocate 4K buffer to handle config data
 	char buffer[bufferSize];
 	int size = exportConfig(buffer, bufferSize);
 	if (saveFile(CONFIG_FILE_PATH, buffer, size))
 		Serial.println("Config file saved to " + String(CONFIG_FILE_PATH));
 	else
-		Serial.println("Unable to save config file " + String(CONFIG_FILE_PATH));
+		Serial.println("Unable to save config file " +
+					   String(CONFIG_FILE_PATH));
 }
 
-void loadConfig(void)
-{
+void loadConfig(void) {
 	Serial.println("Trying to load config...");
 	FsFileTS configFile = getFile(CONFIG_FILE_PATH);
-	if (configFile)
-	{
+	if (configFile) {
 		// Read entire file into memory, should only be a few KB max
 		char *buffer = (char *)malloc(sizeof(char) * configFile.size());
 		Serial.println("Read config start");
@@ -200,49 +195,49 @@ void loadConfig(void)
 		// Couldn't parse config
 		if (error)
 			Serial.println(error);
-		else
+		else {
 			Serial.println("Config file loaded");
-	}
-	else
-	{
-		Serial.println("No config file found, creating a default /tty2pico.toml file...");
+		}
+	} else {
+		Serial.println(
+			"No config file found, creating a default /tty2pico.toml file...");
 		configFile.close();
 		saveConfig();
 	}
 }
 
-static void setupFlash(void)
-{
+static void setupFlash(void) {
 	Serial.println("Setting up flash storage");
 
-	if (!flash.begin())
-	{
+	if (!flash.begin()) {
 		Serial.println("Error, failed to initialize flash chip!");
-		while(1) yield();
+		while (1) yield();
 	}
 
 	Serial.println("TTY2PICO Flash Storage");
-	Serial.print("JEDEC ID: 0x"); Serial.println(flash.getJEDECID(), HEX);
-	Serial.print("Flash size: "); Serial.print(flash.size() / 1024); Serial.println(" KB");
+	Serial.print("JEDEC ID: 0x");
+	Serial.println(flash.getJEDECID(), HEX);
+	Serial.print("Flash size: ");
+	Serial.print(flash.size() / 1024);
+	Serial.println(" KB");
 
 	// Check we have a valid FAT partition
 	hasFlash = flashfs.begin(&flash);
-	if (!hasFlash)
-	{
+	if (!hasFlash) {
 		formatFlash();
 		hasFlash = flashfs.begin(&flash);
 		if (!hasFlash)
-			Serial.println("Error, failed to mount filesystem! You may need to format it manually as a FAT32 partition.");
+			Serial.println(
+				"Error, failed to mount filesystem! You may need to format it "
+				"manually as a FAT32 partition.");
 	}
 }
 
-static void setupSD(void)
-{
+static void setupSD(void) {
 	Serial.println("Setting up SD storage");
 
 	hasSD = sdfs.begin(getSdSpiConfig());
-	if (!hasSD)
-	{
+	if (!hasSD) {
 		sdfs.errorPrint(&Serial);
 		return;
 	}
@@ -252,19 +247,18 @@ static void setupSD(void)
 	if (hasSD)
 		Serial.println("SD filesystem initialized");
 	else
-		Serial.println("SD filesystem intialization failed, unable to locate root filesystem");
+		Serial.println(
+			"SD filesystem intialization failed, unable to locate root "
+			"filesystem");
 }
 
-void setupStorage(void)
-{
+void setupStorage(void) {
 #ifdef SDCARD_SPI
 	setupSD();
 #endif
-	if (!hasSD)
-		setupFlash();
+	if (!hasSD) setupFlash();
 
-	if (hasSD || hasFlash)
-	{
+	if (hasSD || hasFlash) {
 		if (hasSD)
 			volume = FsVolumeTS(sdfs.vol());
 		else
@@ -281,40 +275,29 @@ void setupStorage(void)
 static String dirText;
 static FsFileTS dir;
 
-bool fileExists(String path)
-{
-	return volume.exists(path.c_str());
-}
+bool fileExists(String path) { return volume.exists(path.c_str()); }
 
-String getName(FsFileTS *file)
-{
+String getName(FsFileTS *file) {
 	char filename[250];
 	file->getName(filename, 250);
 	return String(filename);
 }
 
-String getFullName(FsFileTS *file, const char *directory = nullptr)
-{
+String getFullName(FsFileTS *file, const char *directory = nullptr) {
 	if (directory == nullptr)
 		return dirText + getName(file);
 	else
 		return String(directory) + getName(file);
 }
 
-String getDirectory(void)
-{
-	return getFullName(&dir);
-}
+String getDirectory(void) { return getFullName(&dir); }
 
-int getFileCount(void)
-{
-	if (!dir)
-		return -1;
+int getFileCount(void) {
+	if (!dir) return -1;
 
 	dir.rewindDirectory();
 	int count = 0;
-	while (true)
-	{
+	while (true) {
 		if (dir.openNextFile())
 			count += 1;
 		else
@@ -325,16 +308,14 @@ int getFileCount(void)
 	return count;
 }
 
-String getNextFile(void)
-{
+String getNextFile(void) {
 	FsFileTS entry = dir.openNextFile();
 	return (entry) ? getFullName(&entry) : "";
 }
 
-inline int readFile(FsFileTS *file, uint8_t *buffer, int32_t length, const char *errorMessage = nullptr)
-{
-	if (file->available())
-		return file->read(buffer, length);
+inline int readFile(FsFileTS *file, uint8_t *buffer, int32_t length,
+					const char *errorMessage = nullptr) {
+	if (file->available()) return file->read(buffer, length);
 
 #if VERBOSE_OUTPUT == 1
 	Serial.println(errorMessage);
@@ -342,29 +323,27 @@ inline int readFile(FsFileTS *file, uint8_t *buffer, int32_t length, const char 
 	return 0;
 }
 
-void rewindDirectory(void)
-{
-	if (dir)
-		dir.rewindDirectory();
+void rewindDirectory(void) {
+	if (dir) dir.rewindDirectory();
 }
 
-void setDirectory(String path)
-{
-	if (dir)
-		dir.close();
+void setDirectory(String path) {
+	if (dir) dir.close();
 
 	dir = getFile(path);
-	if (dir)
-	{
+	if (dir) {
 		dirText = path;
 #if VERBOSE_OUTPUT == 1
-		Serial.print("Directory set to: "); Serial.println(path.c_str());
+		Serial.print("Directory set to: ");
+		Serial.println(path.c_str());
 #endif
 	}
 #if VERBOSE_OUTPUT == 1
-	else
-	{
-		Serial.print("Couldn't set directory to: "); Serial.print(path.c_str()); Serial.print(", error code "); Serial.println(dir.getError());
+	else {
+		Serial.print("Couldn't set directory to: ");
+		Serial.print(path.c_str());
+		Serial.print(", error code ");
+		Serial.println(dir.getError());
 	}
 #endif
 }
@@ -373,31 +352,32 @@ void setDirectory(String path)
  * GIF functions
  *************************/
 
-void *gifOpen(const char *filename, int32_t *size)
-{
+void *gifOpen(const char *filename, int32_t *size) {
 	static FsFileTS giffile;
 
 	giffile = getFile(filename);
 
-	if (giffile.available())
-	{
+	if (giffile.available()) {
 		*size = giffile.size();
 #if VERBOSE_OUTPUT == 1
-		Serial.print("Opened file "); Serial.print(String(filename).c_str()); Serial.print(" with file size "); Serial.print(giffile.size()); Serial.println(" bytes");
+		Serial.print("Opened file ");
+		Serial.print(String(filename).c_str());
+		Serial.print(" with file size ");
+		Serial.print(giffile.size());
+		Serial.println(" bytes");
 #endif
 		return &giffile;
 	}
 
 #if VERBOSE_OUTPUT == 1
-	Serial.print("Failed to open "); Serial.println(String(filename).c_str());
+	Serial.print("Failed to open ");
+	Serial.println(String(filename).c_str());
 #endif
 	return NULL;
 }
 
-void gifClose(void *handle)
-{
-	if (handle == nullptr)
-		return;
+void gifClose(void *handle) {
+	if (handle == nullptr) return;
 
 #if VERBOSE_OUTPUT == 1
 	Serial.println("Closing file");
@@ -405,16 +385,14 @@ void gifClose(void *handle)
 	static_cast<FsFileTS *>(handle)->close();
 }
 
-int32_t gifRead(GIFFILE *page, uint8_t *buffer, int32_t length)
-{
+int32_t gifRead(GIFFILE *page, uint8_t *buffer, int32_t length) {
 	FsFileTS *file = static_cast<FsFileTS *>(page->fHandle);
 	int byteCount = readFile(file, buffer, length, "Couldn't read GIF file");
 	page->iPos = file->position();
 	return byteCount;
 }
 
-int32_t gifSeek(GIFFILE *page, int32_t position)
-{
+int32_t gifSeek(GIFFILE *page, int32_t position) {
 	FsFileTS *file = static_cast<FsFileTS *>(page->fHandle);
 	file->seek(position);
 	page->iPos = file->position();
@@ -425,33 +403,32 @@ int32_t gifSeek(GIFFILE *page, int32_t position)
  * PNG functions
  *************************/
 
-void *pngOpen(const char *filename, int32_t *size)
-{
+void *pngOpen(const char *filename, int32_t *size) {
 	static FsFileTS pngfile;
 
 	pngfile = getFile(filename);
 
-	if (pngfile.available())
-	{
+	if (pngfile.available()) {
 		*size = pngfile.size();
 #if VERBOSE_OUTPUT == 1
-		Serial.print("Opened file "); Serial.print(String(filename).c_str()); Serial.print(" with file size "); Serial.print(pngfile.size()); Serial.println(" bytes");
+		Serial.print("Opened file ");
+		Serial.print(String(filename).c_str());
+		Serial.print(" with file size ");
+		Serial.print(pngfile.size());
+		Serial.println(" bytes");
 #endif
 		return &pngfile;
-	}
-	else
-	{
+	} else {
 #if VERBOSE_OUTPUT == 1
-		Serial.print("Failed to open "); Serial.println(String(filename).c_str());
+		Serial.print("Failed to open ");
+		Serial.println(String(filename).c_str());
 #endif
 		return NULL;
 	}
 }
 
-void pngClose(void *handle)
-{
-	if (handle == nullptr)
-		return;
+void pngClose(void *handle) {
+	if (handle == nullptr) return;
 
 #if VERBOSE_OUTPUT == 1
 	Serial.println("Closing file");
@@ -459,14 +436,13 @@ void pngClose(void *handle)
 	static_cast<FsFileTS *>(handle)->close();
 }
 
-int32_t pngRead(PNGFILE *page, uint8_t *buffer, int32_t length)
-{
-	int byteCount = readFile(static_cast<FsFileTS *>(page->fHandle), buffer, length, "Couldn't read PNG file");
+int32_t pngRead(PNGFILE *page, uint8_t *buffer, int32_t length) {
+	int byteCount = readFile(static_cast<FsFileTS *>(page->fHandle), buffer,
+							 length, "Couldn't read PNG file");
 	return byteCount;
 }
 
-int32_t pngSeek(PNGFILE *page, int32_t position)
-{
+int32_t pngSeek(PNGFILE *page, int32_t position) {
 	FsFileTS *file = static_cast<FsFileTS *>(page->fHandle);
 	file->seek(position);
 	page->iPos = file->position();
@@ -477,64 +453,55 @@ int32_t pngSeek(PNGFILE *page, int32_t position)
  * FatFs implementation
  *************************/
 
-DSTATUS disk_status ( BYTE pdrv )
-{
-	(void) pdrv;
+DSTATUS disk_status(BYTE pdrv) {
+	(void)pdrv;
 	return 0;
 }
 
-DSTATUS disk_initialize ( BYTE pdrv )
-{
-	(void) pdrv;
+DSTATUS disk_initialize(BYTE pdrv) {
+	(void)pdrv;
 	return 0;
 }
 
-DRESULT disk_read (
-	BYTE pdrv,    /* Physical drive nmuber to identify the drive */
-	BYTE *buff,   /* Data buffer to store read data */
-	DWORD sector, /* Start sector in LBA */
-	UINT count    /* Number of sectors to read */
-)
-{
-	(void) pdrv;
+DRESULT disk_read(BYTE pdrv,  /* Physical drive nmuber to identify the drive */
+				  BYTE *buff, /* Data buffer to store read data */
+				  DWORD sector, /* Start sector in LBA */
+				  UINT count	/* Number of sectors to read */
+) {
+	(void)pdrv;
 	return flash.readSectors(sector, buff, count) ? RES_OK : RES_ERROR;
 }
 
-DRESULT disk_write (
-	BYTE pdrv,        /* Physical drive nmuber to identify the drive */
-	const BYTE *buff, /* Data to be written */
-	DWORD sector,     /* Start sector in LBA */
-	UINT count        /* Number of sectors to write */
-)
-{
-	(void) pdrv;
+DRESULT disk_write(BYTE pdrv, /* Physical drive nmuber to identify the drive */
+				   const BYTE *buff, /* Data to be written */
+				   DWORD sector,	 /* Start sector in LBA */
+				   UINT count		 /* Number of sectors to write */
+) {
+	(void)pdrv;
 	return flash.writeSectors(sector, buff, count) ? RES_OK : RES_ERROR;
 }
 
-DRESULT disk_ioctl (
-	BYTE pdrv,  /* Physical drive nmuber (0..) */
-	BYTE cmd,   /* Control code */
-	void *buff  /* Buffer to send/receive control data */
-)
-{
-	(void) pdrv;
+DRESULT disk_ioctl(BYTE pdrv, /* Physical drive nmuber (0..) */
+				   BYTE cmd,  /* Control code */
+				   void *buff /* Buffer to send/receive control data */
+) {
+	(void)pdrv;
 
-	switch ( cmd )
-	{
+	switch (cmd) {
 		case CTRL_SYNC:
 			flash.syncDevice();
 			return RES_OK;
 
 		case GET_SECTOR_COUNT:
-			*((DWORD*) buff) = flash.size() / 512;
+			*((DWORD *)buff) = flash.size() / 512;
 			return RES_OK;
 
 		case GET_SECTOR_SIZE:
-			*((WORD*) buff) = 512;
+			*((WORD *)buff) = 512;
 			return RES_OK;
 
 		case GET_BLOCK_SIZE:
-			*((DWORD*) buff) = 8; // erase block size in units of sector size
+			*((DWORD *)buff) = 8;  // erase block size in units of sector size
 			return RES_OK;
 
 		default:


### PR DESCRIPTION
- I figure most users won't have an image for every core so this provides a way to see something nice
- Might also add in some logic so an (optional) file named `default.whatever` takes the place of the MiSTer eyes, would be handy for folks who want to customise their setup
- Also adds a `.clang-format` (Google but with tabs instead of spaces) but only auto-formats the files I touched